### PR TITLE
Use "<cluster name>:<addon name>" for Addon.eks external-name annotation

### DIFF
--- a/apis/composition.yaml
+++ b/apis/composition.yaml
@@ -335,6 +335,12 @@ spec:
           patchSetName: deletionPolicy
         - type: PatchSet
           patchSetName: region
+        - fromFieldPath: status.eks.clusterName
+          toFieldPath: metadata.annotations[crossplane.io/external-name]
+          transforms:
+            - type: string
+              string:
+                fmt: "%s:aws-ebs-csi-driver"
     - name: oidcProvider
       base:
         apiVersion: iam.aws.upbound.io/v1beta1


### PR DESCRIPTION
<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, use the below
line to indicate which issue your PR fixes, for example "Fixes #500":
-->

Fixes #7

This PR adds a patch statement for the `Addon.eks` composed resource, which sets its external-name annotation to `<EKS cluster name>:aws-ebs-csi-driver`. Initially, the external-name is just `aws-ebs-csi-driver`, as it was previously and once the `status.eks.clusterName` is available at the `xeks` XR, it's patched with the specified syntax. 

If there's a way in compositions to directly patch from the `spec` of the composed resource, or directly from one composed (`Cluster.eks`) to another (`Addon.eks`), I think we had better use it. Currently, the data flow for the proposed change is `Cluster.eke` MR -> `xeks` XR -> `Addon.eks`.

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested
Via uptest: https://github.com/upbound/configuration-aws-eks/actions/runs/7037818700

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change. Consider pasting snippets
with the commands or configurations you used to test, in case you or a reviewer
needs to repeat the test in future.
-->
