### PR TITLE
Do not create cluster addon until the cluster is ready

### DIFF
--- a/apis/composition.yaml
+++ b/apis/composition.yaml
@@ -26,7 +26,7 @@ spec:
           fromFieldPath: spec.parameters.region
           toFieldPath: spec.forProvider.region
   resources:
-    - name: controlplaneRole 
+    - name: controlplaneRole
       base:
         apiVersion: iam.aws.upbound.io/v1beta1
         kind: Role
@@ -341,6 +341,8 @@ spec:
             - type: string
               string:
                 fmt: "%s:aws-ebs-csi-driver"
+          policy:
+            fromFieldPath: Required
     - name: oidcProvider
       base:
         apiVersion: iam.aws.upbound.io/v1beta1


### PR DESCRIPTION


<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes

This is to avoid creation of addon too early and not hit

```
    Message:               async create failed: failed to create the resource: [{0 creating EKS Add-On (eks-cluster-123:aws-ebs-csi-driver): ResourceNotFoundException: No cluster found for name: eks-cluster-123.
{
  RespMetadata: {
    StatusCode: 404,
    RequestID: "15df2cd5-0ab0-4dd8-9ac3-a58799f5c731"
  },
  ClusterName: "eks-cluster-123",
  Message_: "No cluster found for name: eks-cluster-123."
}  []}]
```

I have:

- [ ] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change. Consider pasting snippets
with the commands or configurations you used to test, in case you or a reviewer
needs to repeat the test in future.
-->
