### PR TITLE
Instantiate addon only when Cluster is ready

### DIFF
--- a/apis/composition.yaml
+++ b/apis/composition.yaml
@@ -133,7 +133,7 @@ spec:
           policy:
             fromFieldPath: Optional
         - type: ToCompositeFieldPath
-          fromFieldPath: metadata.annotations[crossplane.io/external-name]
+          fromFieldPath: status.atProvider.id
           toFieldPath: status.eks.clusterName
           policy:
             fromFieldPath: Optional
@@ -320,9 +320,6 @@ spec:
       base:
         apiVersion: eks.aws.upbound.io/v1beta1
         kind: Addon
-        metadata:
-          annotations:
-            crossplane.io/external-name: aws-ebs-csi-driver
         spec:
           forProvider:
             addonName: aws-ebs-csi-driver


### PR DESCRIPTION

<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, use the below
line to indicate which issue your PR fixes, for example "Fixes #500":
-->
* Follow-up to #9 providing the full fix
* get clusterName from `status.atProvider`
* remove stale hardcoded external-name


I have:

- [ ] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

uptest below