### PR TITLE
Fix addon instantiation ordering and clean deletion

### DIFF
--- a/apis/composition.yaml
+++ b/apis/composition.yaml
@@ -132,11 +132,23 @@ spec:
           toFieldPath: status.eks.clusterSecurityGroupId
           policy:
             fromFieldPath: Optional
-        - type: ToCompositeFieldPath
-          fromFieldPath: status.atProvider.id
-          toFieldPath: status.eks.clusterName
+    # We need to take control over securityGroup transitively created by EKS
+    # See https://github.com/hashicorp/terraform-provider-aws/issues/11473
+    - name: clusterSecurityGroupImport
+      base:
+        apiVersion: ec2.aws.upbound.io/v1beta1
+        kind: SecurityGroup
+      patches:
+        - type: PatchSet
+          patchSetName: providerConfigRef
+        - type: PatchSet
+          patchSetName: deletionPolicy
+        - type: PatchSet
+          patchSetName: region
+        - fromFieldPath: status.eks.clusterSecurityGroupId
+          toFieldPath: metadata.annotations[crossplane.io/external-name]
           policy:
-            fromFieldPath: Optional
+            fromFieldPath: Required
     - name: clusterSecurityGroupTag
       base:
         apiVersion: ec2.aws.upbound.io/v1beta1
@@ -316,6 +328,11 @@ spec:
           toFieldPath: spec.forProvider.instanceTypes[0]
         - fromFieldPath: spec.parameters.id
           toFieldPath: spec.forProvider.subnetIdSelector.matchLabels[networks.aws.platform.upbound.io/network-id]
+        - type: ToCompositeFieldPath
+          fromFieldPath: status.atProvider.clusterName
+          toFieldPath: status.eks.clusterName
+          policy:
+            fromFieldPath: Optional
     - name: ebsCsiAddon
       base:
         apiVersion: eks.aws.upbound.io/v1beta1
@@ -338,6 +355,34 @@ spec:
             - type: string
               string:
                 fmt: "%s:aws-ebs-csi-driver"
+          policy:
+            fromFieldPath: Required
+    - name: cniAddon
+      base:
+        apiVersion: eks.aws.upbound.io/v1beta1
+        kind: Addon
+        spec:
+          forProvider:
+            addonName: vpc-cni
+            # Important for clean deletion, see https://github.com/terraform-aws-modules/terraform-aws-eks/pull/2743#issuecomment-1717657847
+            # We are using `preserve: false` instead of 'true' to take over the
+            # control of full addon deletion to crossplane reconcilers
+            preserve: false
+            clusterNameSelector:
+              matchControllerRef: true
+      patches:
+        - type: PatchSet
+          patchSetName: providerConfigRef
+        - type: PatchSet
+          patchSetName: deletionPolicy
+        - type: PatchSet
+          patchSetName: region
+        - fromFieldPath: status.eks.clusterName
+          toFieldPath: metadata.annotations[crossplane.io/external-name]
+          transforms:
+            - type: string
+              string:
+                fmt: "%s:vpc-cni"
           policy:
             fromFieldPath: Required
     - name: oidcProvider


### PR DESCRIPTION


<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, use the below
line to indicate which issue your PR fixes, for example "Fixes #500":
-->

* Import eks security group for full control over it
* Enable vpc-cni addon for explicit configuration with preserve: false
* Create addons after nodegroup creation. Before this change, the csi addon stuck in the degraded state for more than 20 minutes
* Now, with a proper ordering, the addons are ready almost immediately after instantiation
```
NAME                                                   READY   SYNCED   EXTERNAL-NAME                                    AGE
addon.eks.aws.upbound.io/configuration-aws-eks-dkwcw   True    True     configuration-aws-eks-4n8fl:aws-ebs-csi-driver   112s
addon.eks.aws.upbound.io/configuration-aws-eks-sq5z6   True    True     configuration-aws-eks-4n8fl:vpc-cni              112s


```

**context on leaked ENIs deletion**

https://github.com/terraform-aws-modules/terraform-aws-eks/pull/2743#issuecomment-1717657847
https://github.com/aws/amazon-vpc-cni-k8s/issues/1223#issuecomment-1386961110
https://github.com/aws/amazon-vpc-cni-k8s/issues/69
https://github.com/aws/amazon-vpc-cni-k8s/issues/2360

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

```
=== CONT  kuttl
    harness.go:402: run tests finished
    harness.go:511: cleaning up
    harness.go:553: skipping cluster tear down
    harness.go:554: to connect to the cluster, run: export KUBECONFIG="/Users/xnull/upbound/configuration-aws-eks/kubeconfig"
--- PASS: kuttl (2066.23s)
    --- PASS: kuttl/harness (0.00s)
        --- PASS: kuttl/harness/case (2065.73s)
PASS
12:00:06 [ OK ] running automated tests
```
