### PR TITLE
Remove usage of standalone Tag to avoid race condition

### DIFF
--- a/apis/composition.yaml
+++ b/apis/composition.yaml
@@ -161,29 +161,8 @@ spec:
                   fromFieldPath: Required
                 toFieldPath: metadata.annotations[crossplane.io/external-name]
                 type: FromCompositeFieldPath
-
-          - name: clusterSecurityGroupTag
-            base:
-              apiVersion: ec2.aws.upbound.io/v1beta1
-              kind: Tag
-              spec:
-                forProvider:
-                  key: eks.aws.platform.upbound.io/discovery
-            patches:
-              - patchSetName: providerConfigRef
-                type: PatchSet
-              - patchSetName: deletionPolicy
-                type: PatchSet
-              - patchSetName: region
-                type: PatchSet
               - fromFieldPath: spec.parameters.id
-                toFieldPath: spec.forProvider.value
-                type: FromCompositeFieldPath
-              - fromFieldPath: status.eks.clusterSecurityGroupId
-                policy:
-                  fromFieldPath: Required
-                toFieldPath: spec.forProvider.resourceId
-                type: FromCompositeFieldPath
+                toFieldPath: spec.forProvider.tags[eks.aws.platform.upbound.io/discovery]
 
           - name: kubernetesClusterAuth
             base:


### PR DESCRIPTION



### Description of your changes

* I encountered situation when Tag and SecurityGroup were having race condition and discovery tag was disappearing from the external security group resource
* It is safe to deprecate Tag usage as we have SSA with the switch to Functions

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

e2e together with https://github.com/upbound/configuration-aws-eks-karpenter/ and associate discovery

Plus uptest below