### PR TITLE
feat(oidc): add pod identity audience to use pod identity

### DIFF
--- a/apis/composition.yaml
+++ b/apis/composition.yaml
@@ -406,6 +406,7 @@ spec:
                 forProvider:
                   clientIdList:
                     - sts.amazonaws.com
+                    - pods.eks.amazonaws.com
                   thumbprintList:
                     - 9e99a48a9960b14926bb7f3b02e22da2b0ab7280
             patches:


### PR DESCRIPTION
<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes
to use `pod identity` feature (https://aws.amazon.com/blogs/containers/amazon-eks-pod-identity-a-new-way-for-applications-on-eks-to-obtain-iam-credentials/) instead/in parallel of/with `irsa` in EKS Clusters we need to set pods.eks.amazonaws.com ad audience in `OpenIDConnectProvider `

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, use the below
line to indicate which issue your PR fixes, for example "Fixes #500":
-->

Fixes #

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested
install Crossplane and Provider-AWS ( with pod-identity ) on a EKS Cluster and provision a resource 

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change. Consider pasting snippets
with the commands or configurations you used to test, in case you or a reviewer
needs to repeat the test in future.
-->
