### PR TITLE
Provide alternative XEKS composition with function-kcl

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,7 @@ build.init: $(UP)
 SKIP_DELETE ?=
 uptest: $(UPTEST) $(KUBECTL) $(KUTTL)
 	@$(INFO) running automated tests
-	@KUBECTL=$(KUBECTL) KUTTL=$(KUTTL) CROSSPLANE_NAMESPACE=$(CROSSPLANE_NAMESPACE) $(UPTEST) e2e examples/network-xr.yaml,examples/eks-xr-kcl.yaml --data-source="${UPTEST_DATASOURCE_PATH}" --setup-script=test/setup.sh --default-timeout=2400 $(SKIP_DELETE) || $(FAIL)
+	@KUBECTL=$(KUBECTL) KUTTL=$(KUTTL) CROSSPLANE_NAMESPACE=$(CROSSPLANE_NAMESPACE) $(UPTEST) e2e examples/network-xr.yaml,examples/network-xr-kcl.yaml,examples/eks-xr.yaml,examples/eks-xr-kcl.yaml --data-source="${UPTEST_DATASOURCE_PATH}" --setup-script=test/setup.sh --default-timeout=2400 $(SKIP_DELETE) || $(FAIL)
 	@$(OK) running automated tests
 
 # This target requires the following environment variables to be set:

--- a/Makefile
+++ b/Makefile
@@ -63,17 +63,20 @@ build.init: $(UP)
 # - To ensure the proper functioning of the end-to-end test resource pre-deletion hook, it is crucial to arrange your resources appropriately.
 #   You can check the basic implementation here: https://github.com/upbound/uptest/blob/main/internal/templates/01-delete.yaml.tmpl.
 # - UPTEST_DATASOURCE_PATH (optional), see https://github.com/upbound/uptest#injecting-dynamic-values-and-datasource
+SKIP_DELETE ?=
 uptest: $(UPTEST) $(KUBECTL) $(KUTTL)
 	@$(INFO) running automated tests
-	@KUBECTL=$(KUBECTL) KUTTL=$(KUTTL) CROSSPLANE_NAMESPACE=$(CROSSPLANE_NAMESPACE) $(UPTEST) e2e examples/network-xr.yaml,examples/eks-xr.yaml --data-source="${UPTEST_DATASOURCE_PATH}" --setup-script=test/setup.sh --default-timeout=2400 || $(FAIL)
+	@KUBECTL=$(KUBECTL) KUTTL=$(KUTTL) CROSSPLANE_NAMESPACE=$(CROSSPLANE_NAMESPACE) $(UPTEST) e2e examples/network-xr.yaml,examples/eks-xr-kcl.yaml --data-source="${UPTEST_DATASOURCE_PATH}" --setup-script=test/setup.sh --default-timeout=2400 $(SKIP_DELETE) || $(FAIL)
 	@$(OK) running automated tests
 
 # This target requires the following environment variables to be set:
 # - UPTEST_CLOUD_CREDENTIALS, cloud credentials for the provider being tested, e.g. export UPTEST_CLOUD_CREDENTIALS=$(cat ~/.aws/credentials)
+# Use `make e2e SKIP_DELETE=--skip-delete` to skip deletion of resources created during the test.
 e2e: build controlplane.up local.xpkg.deploy.configuration.$(PROJECT_NAME) uptest
 
 render:
 	crossplane beta render examples/eks-xr.yaml apis/composition.yaml examples/functions.yaml -r
+	crossplane beta render examples/eks-xr.yaml apis/composition-kcl.yaml examples/functions.yaml -r
 
 yamllint:
 	@$(INFO) running yamllint

--- a/apis/composition-kcl.yaml
+++ b/apis/composition-kcl.yaml
@@ -300,7 +300,7 @@ spec:
                   metadata.namespace = "kube-system"
                   metadata.name = "aws-auth"
                   data = {
-                    mapRoles = """
+                    mapRoles = """\
                       - groups:
                         - system:bootstrappers
                         - system:nodes
@@ -316,8 +316,7 @@ spec:
                         rolearn: {}
                         username: adminrole
                     """.format(nodeGroupRoleArn, autoscalerArn, adminRoleArn)
-
-                    mapUsers = """
+                    mapUsers = """\
                       - groups:
                         - system:masters
                         userarn: {}

--- a/apis/composition-kcl.yaml
+++ b/apis/composition-kcl.yaml
@@ -25,10 +25,15 @@ spec:
             providerConfigName = option("params")?.oxr?.spec.parameters.providerConfigName or "default"
             deletionPolicy = option("params")?.oxr?.spec.parameters.deletionPolicy or "Delete"
             region = option("params")?.oxr?.spec.parameters.region or ""
+            id = option("params")?.oxr?.spec.parameters.id or ""
+
             role = {
               apiVersion = "iam.aws.upbound.io/v1beta1"
               kind = "Role"
               metadata.name = xrName + "-iam-role"
+              metadata.labels = {
+                "role" = "controlplane"
+              }
               spec.providerConfigRef.name = providerConfigName
               spec.deletionPolicy = deletionPolicy
               spec.forProvider.assumeRolePolicy = """{
@@ -49,7 +54,74 @@ spec:
                     }
                   """
             }
-            items = [role]
+
+            clusterRolePolicyAttachment = {
+              apiVersion = "iam.aws.upbound.io/v1beta1"
+              kind = "RolePolicyAttachment"
+              metadata.name = xrName + "-cluster-role-policy-attachment"
+              spec.providerConfigRef.name = providerConfigName
+              spec.deletionPolicy = deletionPolicy
+              spec.forProvider = {
+                policyArn = "arn:aws:iam::aws:policy/AmazonEKSClusterPolicy"
+                roleSelector = {
+                  matchControllerRef = True
+                  matchLabels = {
+                    "role" = "controlplane"
+                  }
+                }
+              }
+            }
+
+            kubernetesVersion = option("params")?.oxr?.spec.parameters.version or ""
+            kubernetesCluster = {
+              apiVersion = "eks.aws.upbound.io/v1beta1"
+              kind = "Cluster"
+              metadata.name = xrName + "-kubernetes-cluster"
+              spec.providerConfigRef.name = providerConfigName
+              spec.deletionPolicy = deletionPolicy
+              spec.forProvider = {
+                region = region
+                version = kubernetesVersion
+                roleArnSelector = {
+                  matchControllerRef = True
+                  matchLabels = {
+                    "role" = "controlplane"
+                  }
+                }
+                vpcConfig = [
+                  {
+                    endpointPrivateAccess = True
+                    subnetIdSelector.matchLabels = {
+                      "access" = "public"
+                      "networks.aws.platform.upbound.io/network-id" = id
+                    }
+                  }
+                ]
+              }
+            }
+
+            clusterSecurityGroupId = option("params")?.ocds?[xrName + "-kubernetes-cluster"]?.Resource?.status?.atProvider?.vpcConfig?[0]?.clusterSecurityGroupId
+            if clusterSecurityGroupId:
+              clusterSecurityGroupImport = {
+                apiVersion = "ec2.aws.upbound.io/v1beta1"
+                kind = "SecurityGroup"
+                metadata.name = clusterSecurityGroupId
+                spec.providerConfigRef.name = providerConfigName
+                spec.deletionPolicy = deletionPolicy
+                spec.forProvider = {
+                  region = region
+                  tags = {
+                    "eks.aws.platform.upbound.io/discovery" = id
+                  }
+                }
+              }
+
+            items = [
+              role,
+              clusterRolePolicyAttachment,
+              kubernetesCluster,
+              clusterSecurityGroupImport
+            ]
 
     - step: automatically-detect-ready-composed-resources
       functionRef:

--- a/apis/composition-kcl.yaml
+++ b/apis/composition-kcl.yaml
@@ -1,0 +1,56 @@
+apiVersion: apiextensions.crossplane.io/v1
+kind: Composition
+metadata:
+  name: kcl.xeks.aws.platform.upbound.io
+  labels:
+    provider: aws
+    function: kcl
+spec:
+  writeConnectionSecretsToNamespace: upbound-system
+  compositeTypeRef:
+    apiVersion: aws.platform.upbound.io/v1alpha1
+    kind: XEKS
+  mode: Pipeline
+  pipeline:
+    - step: kcl
+      functionRef:
+        name: crossplane-contrib-function-kcl
+      input:
+        apiVersion: krm.kcl.dev/v1alpha1
+        kind: KCLRun
+        spec:
+          target: Resources
+          source: |
+            xrName = option("params")?.oxr?.metadata.name
+            providerConfigName = option("params")?.oxr?.spec.parameters.providerConfigName or "default"
+            deletionPolicy = option("params")?.oxr?.spec.parameters.deletionPolicy or "Delete"
+            region = option("params")?.oxr?.spec.parameters.region or ""
+            role = {
+              apiVersion = "iam.aws.upbound.io/v1beta1"
+              kind = "Role"
+              metadata.name = xrName + "-iam-role"
+              spec.providerConfigRef.name = providerConfigName
+              spec.deletionPolicy = deletionPolicy
+              spec.forProvider.assumeRolePolicy = """{
+                      "Version": "2012-10-17",
+                      "Statement": [
+                          {
+                              "Effect": "Allow",
+                              "Principal": {
+                                  "Service": [
+                                      "eks.amazonaws.com"
+                                  ]
+                              },
+                              "Action": [
+                                  "sts:AssumeRole"
+                              ]
+                          }
+                      ]
+                    }
+                  """
+            }
+            items = [role]
+
+    - step: automatically-detect-ready-composed-resources
+      functionRef:
+        name: crossplane-contrib-function-auto-ready

--- a/apis/composition-kcl.yaml
+++ b/apis/composition-kcl.yaml
@@ -186,6 +186,37 @@ spec:
             } for i, p in nodeGroupRolePolicies]
 
 
+            nodeCount = option("params")?.oxr?.spec.parameters.nodes.count or ""
+            instanceType = option("params")?.oxr?.spec.parameters.nodes.instanceType or ""
+            nodeGroupPublic = {
+              apiVersion = "eks.aws.upbound.io/v1beta1"
+              kind = "NodeGroup"
+              metadata.name = xrName + "-nodegroup-public"
+              spec.providerConfigRef.name = providerConfigName
+              spec.deletionPolicy = deletionPolicy
+              spec.forProvider = {
+                region = region
+                clusterNameSelector.matchControllerRef = True
+                nodeRoleArnSelector = {
+                  matchControllerRef = True
+                  matchLabels = {
+                    "role" = "nodegroup"
+                  }
+                }
+                scalingConfig = [{
+                  desiredSize = nodeCount
+                  maxSize = 100
+                  minSize = 1
+                }]
+                instanceTypes = [instanceType]
+                subnetIdSelector.matchLabels = {
+                  "networks.aws.platform.upbound.io/network-id" = id
+                  "access" = "public"
+                }
+              }
+            }
+
+
             items = [
               role,
               clusterRolePolicyAttachment,
@@ -193,6 +224,7 @@ spec:
               clusterSecurityGroupImport,
               kubernetesClusterAuth,
               nodegroupRole,
+              nodeGroupPublic,
             ] + nodeGroupRolePolicyAttachments
 
     - step: automatically-detect-ready-composed-resources

--- a/apis/composition-kcl.yaml
+++ b/apis/composition-kcl.yaml
@@ -99,7 +99,7 @@ spec:
               }
             }
 
-            clusterSecurityGroupId = option("params")?.ocds?[xrName + "-kubernetes-cluster"]?.Resource?.status?.atProvider?.vpcConfig?[0]?.clusterSecurityGroupId
+            clusterSecurityGroupId = option("params")?.ocds?[xrName + "-kubernetes-cluster"]?.Resource?.status?.atProvider?.vpcConfig?[0]?.clusterSecurityGroupId or False
             if clusterSecurityGroupId:
               clusterSecurityGroupImport = {
                 apiVersion = "ec2.aws.upbound.io/v1beta1"
@@ -247,9 +247,10 @@ spec:
             providerConfigs = [{
               apiVersion = "{}.crossplane.io/v1alpha1".format(t)
               kind = "ProviderConfig"
-              metadata.name = id + "-" + t # need to deviate metadata.name until https://github.com/crossplane-contrib/function-kcl/issues/77 is fixed
+              metadata.name = id
               metadata.annotations = {
                   "krm.kcl.dev/ready": "True"
+                  "krm.kcl.dev/composition-resource-name" = "providerConfig-" + t
               }
               spec.credentials = {
                   secretRef = {
@@ -267,7 +268,7 @@ spec:
               apiVersion = "kubernetes.crossplane.io/v1alpha2"
               kind = "Object"
               metadata.name = id + "-irsa-settings"
-              spec.providerConfigRef.name = id + "-kubernetes"
+              spec.providerConfigRef.name = id
               spec.deletionPolicy = "Orphan"
               spec.forProvider = {
                 manifest: {
@@ -291,7 +292,7 @@ spec:
               apiVersion = "kubernetes.crossplane.io/v1alpha2"
               kind = "Object"
               metadata.name = id + "-aws-auth"
-              spec.providerConfigRef.name = id + "-kubernetes"
+              spec.providerConfigRef.name = id
               spec.deletionPolicy = "Orphan"
               spec.forProvider = {
                 manifest: {

--- a/apis/composition-kcl.yaml
+++ b/apis/composition-kcl.yaml
@@ -19,7 +19,6 @@ spec:
         apiVersion: krm.kcl.dev/v1alpha1
         kind: KCLRun
         spec:
-          target: Resources
           source: |
             xrName = option("params")?.oxr?.metadata.name
             providerConfigName = option("params")?.oxr?.spec.parameters.providerConfigName or "default"
@@ -244,16 +243,34 @@ spec:
               }
             }
 
+            providerConfigHelm = {
+              apiVersion = "helm.crossplane.io/v1beta1"
+              kind = "ProviderConfig"
+              metadata.name = xrName
+              metadata.annotations = {
+                  "krm.kcl.dev/ready": "True"
+              }
+              spec.credentials = {
+                  secretRef = {
+                    name = "{}-ekscluster".format(uid)
+                    namespace = connectionSecretNamespace
+                    key = "kubeconfig"
+                  }
+                  source = "Secret"
+                }
+            }
+
 
             items = [
-              role,
-              clusterRolePolicyAttachment,
-              kubernetesCluster,
-              clusterSecurityGroupImport,
-              kubernetesClusterAuth,
-              nodegroupRole,
-              nodeGroupPublic,
-              oidcProvider,
+              role
+              clusterRolePolicyAttachment
+              kubernetesCluster
+              clusterSecurityGroupImport
+              kubernetesClusterAuth
+              nodegroupRole
+              nodeGroupPublic
+              oidcProvider
+              providerConfigHelm
             ] + nodeGroupRolePolicyAttachments + eksAddons
 
     - step: automatically-detect-ready-composed-resources

--- a/apis/composition-kcl.yaml
+++ b/apis/composition-kcl.yaml
@@ -227,7 +227,7 @@ spec:
                 addonName = a
                 clusterNameSelector.matchControllerRef = True
               }
-            } for i, a in eksAddonNames]
+            } for a in eksAddonNames]
 
             eksOidcIssuer = option("params")?.ocds?[xrName + "-kubernetes-cluster"]?.Resource?.status?.atProvider?.identity?[0]?.oidc?[0]?.issuer or ""
             oidcProvider = {
@@ -243,10 +243,11 @@ spec:
               }
             }
 
-            providerConfigHelm = {
-              apiVersion = "helm.crossplane.io/v1beta1"
+            providerConfigTypes = ["helm", "kubernetes"]
+            providerConfigs = [{
+              apiVersion = "{}.crossplane.io/v1alpha1".format(t)
               kind = "ProviderConfig"
-              metadata.name = xrName
+              metadata.name = id + "-" + t
               metadata.annotations = {
                   "krm.kcl.dev/ready": "True"
               }
@@ -258,7 +259,7 @@ spec:
                   }
                   source = "Secret"
                 }
-            }
+            } for t in providerConfigTypes]
 
 
             items = [
@@ -270,8 +271,7 @@ spec:
               nodegroupRole
               nodeGroupPublic
               oidcProvider
-              providerConfigHelm
-            ] + nodeGroupRolePolicyAttachments + eksAddons
+            ] + nodeGroupRolePolicyAttachments + eksAddons + providerConfigs
 
     - step: automatically-detect-ready-composed-resources
       functionRef:

--- a/apis/composition-kcl.yaml
+++ b/apis/composition-kcl.yaml
@@ -116,11 +116,59 @@ spec:
                 }
               }
 
+            uid = option("params")?.oxr?.metadata.uid or ""
+            connectionSecretNamespace = option("params")?.oxr?.spec.writeConnectionSecretToRef.namespace or "upbound-system"
+            kubernetesClusterAuth = {
+              apiVersion = "eks.aws.upbound.io/v1beta1"
+              kind = "ClusterAuth"
+              metadata.name = xrName + "cluster-auth"
+              spec.providerConfigRef.name = providerConfigName
+              spec.deletionPolicy = deletionPolicy
+              spec.forProvider = {
+                region = region
+                clusterNameSelector.matchControllerRef = True
+              }
+              spec.writeConnectionSecretToRef = {
+                  name = "{}-ekscluster".format(uid)
+                  namespace = connectionSecretNamespace
+              }
+            }
+
+            nodegroupRole = {
+              apiVersion = "iam.aws.upbound.io/v1beta1"
+              kind = "Role"
+              metadata.name = xrName + "-nodegroup-role"
+              metadata.labels = {
+                "role" = "nodegroup"
+              }
+              spec.providerConfigRef.name = providerConfigName
+              spec.deletionPolicy = deletionPolicy
+              spec.forProvider.assumeRolePolicy = """{
+                      "Version": "2012-10-17",
+                      "Statement": [
+                          {
+                              "Effect": "Allow",
+                              "Principal": {
+                                  "Service": [
+                                      "ec2.amazonaws.com"
+                                  ]
+                              },
+                              "Action": [
+                                  "sts:AssumeRole"
+                              ]
+                          }
+                      ]
+                    }
+                  """
+            }
+
             items = [
               role,
               clusterRolePolicyAttachment,
               kubernetesCluster,
-              clusterSecurityGroupImport
+              clusterSecurityGroupImport,
+              kubernetesClusterAuth,
+              nodegroupRole
             ]
 
     - step: automatically-detect-ready-composed-resources

--- a/apis/composition-kcl.yaml
+++ b/apis/composition-kcl.yaml
@@ -162,14 +162,38 @@ spec:
                   """
             }
 
+            nodeGroupRolePolicies = [
+              "arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy",
+              "arn:aws:iam::aws:policy/service-role/AmazonEBSCSIDriverPolicy",
+              "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly",
+            ]
+
+            nodeGroupRolePolicyAttachments = [{
+              apiVersion = "iam.aws.upbound.io/v1beta1"
+              kind = "RolePolicyAttachment"
+              metadata.name = xrName + "-nodegroup-rpa-{}".format(i)
+              spec.providerConfigRef.name = providerConfigName
+              spec.deletionPolicy = deletionPolicy
+              spec.forProvider = {
+                policyArn = p
+                roleSelector = {
+                  matchControllerRef = True
+                  matchLabels = {
+                    "role" = "nodegroup"
+                  }
+                }
+              }
+            } for i, p in nodeGroupRolePolicies]
+
+
             items = [
               role,
               clusterRolePolicyAttachment,
               kubernetesCluster,
               clusterSecurityGroupImport,
               kubernetesClusterAuth,
-              nodegroupRole
-            ]
+              nodegroupRole,
+            ] + nodeGroupRolePolicyAttachments
 
     - step: automatically-detect-ready-composed-resources
       functionRef:

--- a/apis/composition-kcl.yaml
+++ b/apis/composition-kcl.yaml
@@ -247,7 +247,7 @@ spec:
             providerConfigs = [{
               apiVersion = "{}.crossplane.io/v1alpha1".format(t)
               kind = "ProviderConfig"
-              metadata.name = id + "-" + t
+              metadata.name = id + "-" + t # need to deviate metadata.name until https://github.com/crossplane-contrib/function-kcl/issues/77 is fixed
               metadata.annotations = {
                   "krm.kcl.dev/ready": "True"
               }

--- a/apis/composition-kcl.yaml
+++ b/apis/composition-kcl.yaml
@@ -230,6 +230,20 @@ spec:
               }
             } for i, a in eksAddonNames]
 
+            eksOidcIssuer = option("params")?.ocds?[xrName + "-kubernetes-cluster"]?.Resource?.status?.atProvider?.identity?[0]?.oidc?[0]?.issuer or ""
+            oidcProvider = {
+              apiVersion = "iam.aws.upbound.io/v1beta1"
+              kind = "OpenIDConnectProvider"
+              metadata.name = xrName + "-oidc-provider"
+              spec.providerConfigRef.name = providerConfigName
+              spec.deletionPolicy = deletionPolicy
+              spec.forProvider = {
+                clientIdList = ["sts.amazonaws.com"]
+                thumbprintList = ["9e99a48a9960b14926bb7f3b02e22da2b0ab7280"]
+                url = eksOidcIssuer
+              }
+            }
+
 
             items = [
               role,
@@ -239,6 +253,7 @@ spec:
               kubernetesClusterAuth,
               nodegroupRole,
               nodeGroupPublic,
+              oidcProvider,
             ] + nodeGroupRolePolicyAttachments + eksAddons
 
     - step: automatically-detect-ready-composed-resources

--- a/apis/composition-kcl.yaml
+++ b/apis/composition-kcl.yaml
@@ -216,6 +216,20 @@ spec:
               }
             }
 
+            eksAddonNames = ["aws-ebs-csi-driver", "vpc-cni"]
+            eksAddons = [{
+              apiVersion = "eks.aws.upbound.io/v1beta1"
+              kind = "Addon"
+              metadata.name = xrName + "-addon-" + a
+              spec.providerConfigRef.name = providerConfigName
+              spec.deletionPolicy = deletionPolicy
+              spec.forProvider = {
+                region = region
+                addonName = a
+                clusterNameSelector.matchControllerRef = True
+              }
+            } for i, a in eksAddonNames]
+
 
             items = [
               role,
@@ -225,7 +239,7 @@ spec:
               kubernetesClusterAuth,
               nodegroupRole,
               nodeGroupPublic,
-            ] + nodeGroupRolePolicyAttachments
+            ] + nodeGroupRolePolicyAttachments + eksAddons
 
     - step: automatically-detect-ready-composed-resources
       functionRef:

--- a/apis/composition-kcl.yaml
+++ b/apis/composition-kcl.yaml
@@ -261,6 +261,27 @@ spec:
                 }
             } for t in providerConfigTypes]
 
+            oidcArn = option("params")?.ocds?[xrName + "-kubernetes-cluster"]?.Resource?.status?.atProvider?.arn or ""
+            oidcHost = eksOidcIssuer.strip("https://") or ""
+            irsaSettings = {
+              apiVersion = "kubernetes.crossplane.io/v1alpha2"
+              kind = "Object"
+              metadata.name = id + "-irsa-settings"
+              spec.providerConfigRef.name = id + "-kubernetes"
+              spec.deletionPolicy = "Orphan"
+              spec.forProvider = {
+                manifest: {
+                  apiVersion = "v1"
+                  kind = "ConfigMap"
+                  metadata.namespace = "default"
+                  metadata.name = "{}-irsa-settings".format(id)
+                  data = {
+                    oidc_arn = oidcArn
+                    oidc_host = oidcHost
+                  }
+                }
+              }
+            }
 
             items = [
               role
@@ -271,6 +292,7 @@ spec:
               nodegroupRole
               nodeGroupPublic
               oidcProvider
+              irsaSettings
             ] + nodeGroupRolePolicyAttachments + eksAddons + providerConfigs
 
     - step: automatically-detect-ready-composed-resources

--- a/apis/composition-kcl.yaml
+++ b/apis/composition-kcl.yaml
@@ -99,7 +99,7 @@ spec:
               }
             }
 
-            clusterSecurityGroupId = option("params")?.ocds?[xrName + "-kubernetes-cluster"]?.Resource?.status?.atProvider?.vpcConfig?[0]?.clusterSecurityGroupId or False
+            clusterSecurityGroupId = option("params")?.ocds?[kubernetesCluster.metadata.name]?.Resource?.status?.atProvider?.vpcConfig?[0]?.clusterSecurityGroupId or False
             if clusterSecurityGroupId:
               clusterSecurityGroupImport = {
                 apiVersion = "ec2.aws.upbound.io/v1beta1"
@@ -162,6 +162,7 @@ spec:
             }
 
             nodeGroupRolePolicies = [
+              "arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy",
               "arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy",
               "arn:aws:iam::aws:policy/service-role/AmazonEBSCSIDriverPolicy",
               "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly",
@@ -229,7 +230,7 @@ spec:
               }
             } for a in eksAddonNames]
 
-            eksOidcIssuer = option("params")?.ocds?[xrName + "-kubernetes-cluster"]?.Resource?.status?.atProvider?.identity?[0]?.oidc?[0]?.issuer or ""
+            eksOidcIssuer = option("params")?.ocds?[kubernetesCluster.metadata.name]?.Resource?.status?.atProvider?.identity?[0]?.oidc?[0]?.issuer or ""
             oidcProvider = {
               apiVersion = "iam.aws.upbound.io/v1beta1"
               kind = "OpenIDConnectProvider"
@@ -262,7 +263,7 @@ spec:
                 }
             } for t in providerConfigTypes]
 
-            oidcArn = option("params")?.ocds?[xrName + "-kubernetes-cluster"]?.Resource?.status?.atProvider?.arn or ""
+            oidcArn = option("params")?.ocds?[kubernetesCluster.metadata.name]?.Resource?.status?.atProvider?.arn or ""
             oidcHost = eksOidcIssuer.strip("https://") or ""
             irsaSettings = {
               apiVersion = "kubernetes.crossplane.io/v1alpha2"
@@ -284,7 +285,7 @@ spec:
               }
             }
 
-            nodeGroupRoleArn = option("params")?.ocds?[xrName + "-nodegroup-role"]?.Resource?.status?.atProvider?.arn or ""
+            nodeGroupRoleArn = option("params")?.ocds?[nodegroupRole.metadata.name]?.Resource?.status?.atProvider?.arn or ""
             autoscalerArn = option("params")?.oxr?.spec.parameters.iam.autoscalerArn or ""
             adminRoleArn = option("params")?.oxr?.spec.parameters.iam.roleArn or ""
             adminUser = option("params")?.oxr?.spec.parameters.iam.userArn or ""

--- a/apis/composition-kcl.yaml
+++ b/apis/composition-kcl.yaml
@@ -283,6 +283,62 @@ spec:
               }
             }
 
+            nodeGroupRoleArn = option("params")?.ocds?[xrName + "-nodegroup-role"]?.Resource?.status?.atProvider?.arn or ""
+            autoscalerArn = option("params")?.oxr?.spec.parameters.iam.autoscalerArn or ""
+            adminRoleArn = option("params")?.oxr?.spec.parameters.iam.roleArn or ""
+            adminUser = option("params")?.oxr?.spec.parameters.iam.userArn or ""
+            awsAuth = {
+              apiVersion = "kubernetes.crossplane.io/v1alpha2"
+              kind = "Object"
+              metadata.name = id + "-aws-auth"
+              spec.providerConfigRef.name = id + "-kubernetes"
+              spec.deletionPolicy = "Orphan"
+              spec.forProvider = {
+                manifest: {
+                  apiVersion = "v1"
+                  kind = "ConfigMap"
+                  metadata.namespace = "kube-system"
+                  metadata.name = "aws-auth"
+                  data = {
+                    mapRoles = """
+                      - groups:
+                        - system:bootstrappers
+                        - system:nodes
+                        rolearn: {}
+                        username: system:node:{{EC2PrivateDNSName}}
+                      - groups:
+                        - system:bootstrappers
+                        - system:nodes
+                        rolearn: {}
+                        username: system:node:{{EC2PrivateDNSName}}
+                      - groups:
+                        - system:masters
+                        rolearn: {}
+                        username: adminrole
+                    """.format(nodeGroupRoleArn, autoscalerArn, adminRoleArn)
+
+                    mapUsers = """
+                      - groups:
+                        - system:masters
+                        userarn: {}
+                        username: adminuser
+                    """.format(adminUser)
+                  }
+                }
+              }
+            }
+
+            connectionDetails = {
+              apiVersion: "meta.krm.kcl.dev/v1alpha1"
+              kind: "CompositeConnectionDetails"
+              if kubernetesClusterAuth.metadata.name in option("params").ocds:
+                  data: {
+                      kubeconfig = option("params")?.ocds[kubernetesClusterAuth.metadata.name].ConnectionDetails.kubeconfig
+                  }
+              else:
+                  data: {}
+            }
+
             items = [
               role
               clusterRolePolicyAttachment
@@ -293,6 +349,8 @@ spec:
               nodeGroupPublic
               oidcProvider
               irsaSettings
+              awsAuth
+              connectionDetails
             ] + nodeGroupRolePolicyAttachments + eksAddons + providerConfigs
 
     - step: automatically-detect-ready-composed-resources

--- a/apis/composition-kcl.yaml
+++ b/apis/composition-kcl.yaml
@@ -216,33 +216,38 @@ spec:
               }
             }
 
-            eksAddonNames = ["aws-ebs-csi-driver", "vpc-cni"]
-            eksAddons = [{
-              apiVersion = "eks.aws.upbound.io/v1beta1"
-              kind = "Addon"
-              metadata.name = xrName + "-addon-" + a
-              spec.providerConfigRef.name = providerConfigName
-              spec.deletionPolicy = deletionPolicy
-              spec.forProvider = {
-                region = region
-                addonName = a
-                clusterNameSelector.matchControllerRef = True
-              }
-            } for a in eksAddonNames]
+            nodeGroupStatus = option("params")?.ocds?[nodeGroupPublic.metadata.name]?.Resource?.status?.atProvider?.status or ""
+            if nodeGroupStatus == "ACTIVE":
+              eksAddonNames = ["aws-ebs-csi-driver", "vpc-cni"]
+              _eksAddons = [{
+                apiVersion = "eks.aws.upbound.io/v1beta1"
+                kind = "Addon"
+                metadata.name = xrName + "-addon-" + a
+                spec.providerConfigRef.name = providerConfigName
+                spec.deletionPolicy = deletionPolicy
+                spec.forProvider = {
+                  region = region
+                  addonName = a
+                  clusterNameSelector.matchControllerRef = True
+                }
+              } for a in eksAddonNames]
+            else:
+              _eksAddons = []
 
             eksOidcIssuer = option("params")?.ocds?[kubernetesCluster.metadata.name]?.Resource?.status?.atProvider?.identity?[0]?.oidc?[0]?.issuer or ""
-            oidcProvider = {
-              apiVersion = "iam.aws.upbound.io/v1beta1"
-              kind = "OpenIDConnectProvider"
-              metadata.name = xrName + "-oidc-provider"
-              spec.providerConfigRef.name = providerConfigName
-              spec.deletionPolicy = deletionPolicy
-              spec.forProvider = {
-                clientIdList = ["sts.amazonaws.com"]
-                thumbprintList = ["9e99a48a9960b14926bb7f3b02e22da2b0ab7280"]
-                url = eksOidcIssuer
+            if len(eksOidcIssuer) > 0:
+              oidcProvider = {
+                apiVersion = "iam.aws.upbound.io/v1beta1"
+                kind = "OpenIDConnectProvider"
+                metadata.name = xrName + "-oidc-provider"
+                spec.providerConfigRef.name = providerConfigName
+                spec.deletionPolicy = deletionPolicy
+                spec.forProvider = {
+                  clientIdList = ["sts.amazonaws.com"]
+                  thumbprintList = ["9e99a48a9960b14926bb7f3b02e22da2b0ab7280"]
+                  url = eksOidcIssuer
+                }
               }
-            }
 
             providerConfigTypes = ["helm", "kubernetes"]
             providerConfigs = [{
@@ -303,27 +308,25 @@ spec:
                   metadata.name = "aws-auth"
                   data = {
                     mapRoles = """\
-                      - groups:
-                        - system:bootstrappers
-                        - system:nodes
-                        rolearn: {}
-                        username: system:node:{{EC2PrivateDNSName}}
-                      - groups:
-                        - system:bootstrappers
-                        - system:nodes
-                        rolearn: {}
-                        username: system:node:{{EC2PrivateDNSName}}
-                      - groups:
-                        - system:masters
-                        rolearn: {}
-                        username: adminrole
-                    """.format(nodeGroupRoleArn, autoscalerArn, adminRoleArn)
+            - groups:
+              - system:bootstrappers
+              - system:nodes
+              rolearn: ${nodeGroupRoleArn}
+              username: system:node:{{EC2PrivateDNSName}}
+            - groups:
+              - system:bootstrappers
+              - system:nodes
+              rolearn: ${autoscalerArn}
+              username: system:node:{{EC2PrivateDNSName}}
+            - groups:
+              - system:masters
+              rolearn: ${adminRoleArn}
+              username: adminrole"""
                     mapUsers = """\
-                      - groups:
-                        - system:masters
-                        userarn: {}
-                        username: adminuser
-                    """.format(adminUser)
+            - groups:
+              - system:masters
+              userarn: ${adminUser}
+              username: adminuser"""
                   }
                 }
               }
@@ -352,7 +355,7 @@ spec:
               irsaSettings
               awsAuth
               connectionDetails
-            ] + nodeGroupRolePolicyAttachments + eksAddons + providerConfigs
+            ] + nodeGroupRolePolicyAttachments + _eksAddons + providerConfigs
 
     - step: automatically-detect-ready-composed-resources
       functionRef:

--- a/apis/composition.yaml
+++ b/apis/composition.yaml
@@ -4,6 +4,7 @@ metadata:
   name: xeks.aws.platform.upbound.io
   labels:
     provider: aws
+    function: patch-and-transform
 spec:
   writeConnectionSecretsToNamespace: upbound-system
   compositeTypeRef:

--- a/apis/definition.yaml
+++ b/apis/definition.yaml
@@ -3,6 +3,8 @@ kind: CompositeResourceDefinition
 metadata:
   name: xeks.aws.platform.upbound.io
 spec:
+  defaultCompositionRef:
+    name: xeks.aws.platform.upbound.io
   connectionSecretKeys:
     - kubeconfig
   group: aws.platform.upbound.io

--- a/crossplane.yaml
+++ b/crossplane.yaml
@@ -38,7 +38,7 @@ spec:
       version: "v0.4.0"
     - function: xpkg.upbound.io/crossplane-contrib/function-kcl
       # renovate: datasource=github-releases depName=crossplane-contrib/function-kcl
-      version: "v0.5.1"
+      version: "v0.6.0"
     - function: xpkg.upbound.io/crossplane-contrib/function-auto-ready
       # renovate: datasource=github-releases depName=crossplane-contrib/function-auto-ready
       version: "v0.2.1"

--- a/crossplane.yaml
+++ b/crossplane.yaml
@@ -36,3 +36,9 @@ spec:
     - function: xpkg.upbound.io/crossplane-contrib/function-patch-and-transform
       # renovate: datasource=github-releases depName=crossplane-contrib/function-patch-and-transform
       version: "v0.4.0"
+    - function: xpkg.upbound.io/crossplane-contrib/function-kcl
+      # renovate: datasource=github-releases depName=crossplane-contrib/function-kcl
+      version: "v0.5.1"
+    - function: xpkg.upbound.io/crossplane-contrib/function-auto-ready
+      # renovate: datasource=github-releases depName=crossplane-contrib/function-auto-ready
+      version: "v0.2.1"

--- a/examples/eks-xr-kcl.yaml
+++ b/examples/eks-xr-kcl.yaml
@@ -1,0 +1,22 @@
+apiVersion: aws.platform.upbound.io/v1alpha1
+kind: XEKS
+metadata:
+  name: configuration-aws-eks-kcl
+spec:
+  compositionSelector:
+    matchLabels:
+      function: kcl
+  parameters:
+    id: configuration-aws-eks
+    region: us-west-2
+    version: "1.27"
+    iam:
+      # replace with your custom arn like:
+      # roleArn: arn:aws:iam::123456789:role/AWSReservedSSO_AdministratorAccess_d703c73ed340fde7
+      roleArn: ${data.aws_eks_iam_default_admin}
+    nodes:
+      count: 3
+      instanceType: t3.small
+  writeConnectionSecretToRef:
+    name: configuration-aws-eks-kubeconfig
+    namespace: upbound-system

--- a/examples/eks-xr-kcl.yaml
+++ b/examples/eks-xr-kcl.yaml
@@ -7,7 +7,7 @@ spec:
     matchLabels:
       function: kcl
   parameters:
-    id: configuration-aws-eks
+    id: configuration-aws-eks-kcl
     region: us-west-2
     version: "1.27"
     iam:
@@ -18,5 +18,5 @@ spec:
       count: 1
       instanceType: t3.small
   writeConnectionSecretToRef:
-    name: configuration-aws-eks-kubeconfig
+    name: configuration-aws-eks-kcl-kubeconfig
     namespace: upbound-system

--- a/examples/eks-xr-kcl.yaml
+++ b/examples/eks-xr-kcl.yaml
@@ -15,7 +15,7 @@ spec:
       # roleArn: arn:aws:iam::123456789:role/AWSReservedSSO_AdministratorAccess_d703c73ed340fde7
       roleArn: ${data.aws_eks_iam_default_admin}
     nodes:
-      count: 3
+      count: 1
       instanceType: t3.small
   writeConnectionSecretToRef:
     name: configuration-aws-eks-kubeconfig

--- a/examples/functions.yaml
+++ b/examples/functions.yaml
@@ -3,4 +3,20 @@ kind: Function
 metadata:
   name: crossplane-contrib-function-patch-and-transform
 spec:
-  package: xpkg.upbound.io/crossplane-contrib/function-patch-and-transform:v0.2.1
+  package: xpkg.upbound.io/crossplane-contrib/function-patch-and-transform:v0.4.0
+---
+apiVersion: pkg.crossplane.io/v1beta1
+kind: Function
+metadata:
+  name: crossplane-contrib-function-kcl
+spec:
+  package: xpkg.upbound.io/crossplane-contrib/function-kcl:v0.5.1
+---
+apiVersion: pkg.crossplane.io/v1beta1
+kind: Function
+metadata:
+  name: crossplane-contrib-function-auto-ready
+spec:
+  package: xpkg.upbound.io/crossplane-contrib/function-auto-ready:v0.2.1
+
+

--- a/examples/network-xr-kcl.yaml
+++ b/examples/network-xr-kcl.yaml
@@ -1,0 +1,8 @@
+apiVersion: aws.platform.upbound.io/v1alpha1
+kind: XNetwork
+metadata:
+  name: configuration-aws-eks-kcl
+spec:
+  parameters:
+    id: configuration-aws-eks-kcl
+    region: us-west-2


### PR DESCRIPTION
<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes

* Build alternative Composition with https://github.com/crossplane-contrib/function-kcl as PoC
* Utilize loops and conditionals
* Utilize data passing between MRs without bi-directional patching
* There are still some rough edges related to upstream https://github.com/crossplane-contrib/function-kcl/issues/71 and https://github.com/crossplane-contrib/function-kcl/issues/77 - (upd: both already fixed!)
* Less verbose, more brief implementation achieved, around 38% reduction in Composition code size:
```
wc -l apis/composition.yaml
     584 apis/composition.yaml
 wc -l apis/composition-kcl.yaml
     357 apis/composition-kcl.yaml
```

Fixes #

I have:

- [ ] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

```
k apply -f examples/eks-xr-kcl.yaml
crossplane beta trace xeks configuration-aws-eks-kcl
NAME                                                                               SYNCED   READY   STATUS
XEKS/configuration-aws-eks-kcl                                                     True     True    Available
├─ SecurityGroup/sg-0b1964613fb0c7449                                              True     True    Available
├─ Addon/configuration-aws-eks-kcl-addon-aws-ebs-csi-driver                        True     True    Available
├─ Addon/configuration-aws-eks-kcl-addon-vpc-cni                                   True     True    Available
├─ ClusterAuth/configuration-aws-eks-kclcluster-auth                               True     True    Available
├─ Cluster/configuration-aws-eks-kcl-kubernetes-cluster                            True     True    Available
├─ NodeGroup/configuration-aws-eks-kcl-nodegroup-public                            True     True    Available
├─ ProviderConfig/configuration-aws-eks-helm                                       -        -
├─ OpenIDConnectProvider/configuration-aws-eks-kcl-oidc-provider                   True     True    Available
├─ RolePolicyAttachment/configuration-aws-eks-kcl-cluster-role-policy-attachment   True     True    Available
├─ RolePolicyAttachment/configuration-aws-eks-kcl-nodegroup-rpa-0                  True     True    Available
├─ RolePolicyAttachment/configuration-aws-eks-kcl-nodegroup-rpa-1                  True     True    Available
├─ RolePolicyAttachment/configuration-aws-eks-kcl-nodegroup-rpa-2                  True     True    Available
├─ Role/configuration-aws-eks-kcl-iam-role                                         True     True    Available
├─ Role/configuration-aws-eks-kcl-nodegroup-role                                   True     True    Available
├─ ProviderConfig/configuration-aws-eks-kubernetes                                 -        -
├─ Object/configuration-aws-eks-aws-auth                                           True     True    Available
└─ Object/configuration-aws-eks-irsa-settings                                      True     True    Available
```

```
make e2e
--- PASS: kuttl (2281.53s)
    --- PASS: kuttl/harness (0.00s)
        --- PASS: kuttl/harness/case (2281.05s)
PASS
12:05:02 [ OK ] running automated tests
```