### PR TITLE
Sequence cluster addons creation

### DIFF
--- a/apis/composition-kcl.yaml
+++ b/apis/composition-kcl.yaml
@@ -76,6 +76,9 @@ spec:
               apiVersion = "eks.aws.upbound.io/v1beta1"
               kind = "Cluster"
               metadata.name = xrName + "-kubernetes-cluster"
+              metadata.annotations = {
+                "krm.kcl.dev/composition-resource-name" = "kubernetesCluster"
+              }
               spec.providerConfigRef.name = providerConfigName
               spec.deletionPolicy = deletionPolicy
               spec.forProvider = {
@@ -120,7 +123,7 @@ spec:
             kubernetesClusterAuth = {
               apiVersion = "eks.aws.upbound.io/v1beta1"
               kind = "ClusterAuth"
-              metadata.name = xrName + "cluster-auth"
+              metadata.name = xrName + "-cluster-auth"
               spec.providerConfigRef.name = providerConfigName
               spec.deletionPolicy = deletionPolicy
               spec.forProvider = {
@@ -192,6 +195,9 @@ spec:
               apiVersion = "eks.aws.upbound.io/v1beta1"
               kind = "NodeGroup"
               metadata.name = xrName + "-nodegroup-public"
+              metadata.annotations = {
+                "krm.kcl.dev/composition-resource-name" = "nodeGroupPublic"
+              }
               spec.providerConfigRef.name = providerConfigName
               spec.deletionPolicy = deletionPolicy
               spec.forProvider = {
@@ -216,23 +222,38 @@ spec:
               }
             }
 
-            nodeGroupStatus = option("params")?.ocds?[nodeGroupPublic.metadata.name]?.Resource?.status?.atProvider?.status or ""
-            if nodeGroupStatus == "ACTIVE":
-              eksAddonNames = ["aws-ebs-csi-driver", "vpc-cni"]
-              _eksAddons = [{
-                apiVersion = "eks.aws.upbound.io/v1beta1"
-                kind = "Addon"
-                metadata.name = xrName + "-addon-" + a
-                spec.providerConfigRef.name = providerConfigName
-                spec.deletionPolicy = deletionPolicy
-                spec.forProvider = {
-                  region = region
-                  addonName = a
-                  clusterNameSelector.matchControllerRef = True
-                }
-              } for a in eksAddonNames]
-            else:
-              _eksAddons = []
+            cniAddon = {
+              apiVersion = "eks.aws.upbound.io/v1beta1"
+              kind = "Addon"
+              metadata.name = xrName + "-cni-addon"
+              metadata.annotations = {
+                "krm.kcl.dev/composition-resource-name" = "cniAddon"
+              }
+              spec.providerConfigRef.name = providerConfigName
+              spec.deletionPolicy = deletionPolicy
+              spec.forProvider = {
+                region = region
+                addonName = "vpc-cni"
+                clusterNameSelector.matchControllerRef = True
+                configurationValues = '{"env": {"AWS_VPC_K8S_CNI_CUSTOM_NETWORK_CFG":"false"}}' # see https://github.com/aws/amazon-vpc-cni-k8s/blob/master/README.md for different options
+              }
+            }
+
+            ebsCsiAddon = {
+              apiVersion = "eks.aws.upbound.io/v1beta1"
+              kind = "Addon"
+              metadata.name = xrName + "-ebs-csi-addon"
+              metadata.annotations = {
+                "krm.kcl.dev/composition-resource-name" = "ebsCsiAddon"
+              }
+              spec.providerConfigRef.name = providerConfigName
+              spec.deletionPolicy = deletionPolicy
+              spec.forProvider = {
+                region = region
+                addonName = "aws-ebs-csi-driver"
+                clusterNameSelector.matchControllerRef = True
+              }
+            }
 
             eksOidcIssuer = option("params")?.ocds?[kubernetesCluster.metadata.name]?.Resource?.status?.atProvider?.identity?[0]?.oidc?[0]?.issuer or ""
             if len(eksOidcIssuer) > 0:
@@ -355,8 +376,23 @@ spec:
               irsaSettings
               awsAuth
               connectionDetails
-            ] + nodeGroupRolePolicyAttachments + _eksAddons + providerConfigs
+              cniAddon
+              ebsCsiAddon
+            ] + nodeGroupRolePolicyAttachments + providerConfigs
 
     - step: automatically-detect-ready-composed-resources
       functionRef:
         name: crossplane-contrib-function-auto-ready
+
+    - step: sequence-creation
+      functionRef:
+        name: crossplane-contrib-function-sequencer
+      input:
+        apiVersion: sequencer.fn.crossplane.io/v1beta1
+        kind: Input
+        rules:
+          - sequence:
+              - kubernetesCluster
+              - cniAddon
+              - nodeGroupPublic
+              - ebsCsiAddon

--- a/apis/composition.yaml
+++ b/apis/composition.yaml
@@ -360,16 +360,6 @@ spec:
                 type: PatchSet
               - patchSetName: region
                 type: PatchSet
-              - fromFieldPath: status.eks.clusterName
-                policy:
-                  fromFieldPath: Required
-                toFieldPath: metadata.annotations[crossplane.io/external-name]
-                transforms:
-                  - string:
-                      fmt: '%s:aws-ebs-csi-driver'
-                      type: Format
-                    type: string
-                type: FromCompositeFieldPath
 
           - name: cniAddon
             base:
@@ -381,6 +371,7 @@ spec:
                   clusterNameSelector:
                     matchControllerRef: true
                   preserve: false
+                  configurationValues: '{"env": {"AWS_VPC_K8S_CNI_CUSTOM_NETWORK_CFG":"false"}}'  # see https://github.com/aws/amazon-vpc-cni-k8s/blob/master/README.md for different options
             patches:
               - patchSetName: providerConfigRef
                 type: PatchSet
@@ -388,16 +379,6 @@ spec:
                 type: PatchSet
               - patchSetName: region
                 type: PatchSet
-              - fromFieldPath: status.eks.clusterName
-                policy:
-                  fromFieldPath: Required
-                toFieldPath: metadata.annotations[crossplane.io/external-name]
-                transforms:
-                  - string:
-                      fmt: '%s:vpc-cni'
-                      type: Format
-                    type: string
-                type: FromCompositeFieldPath
 
           - name: oidcProvider
             base:
@@ -583,3 +564,16 @@ spec:
                   fromFieldPath: Optional
                 toFieldPath: spec.forProvider.manifest.data.mapUsers
                 type: CombineFromComposite
+
+    - step: sequence-creation
+      functionRef:
+        name: crossplane-contrib-function-sequencer
+      input:
+        apiVersion: sequencer.fn.crossplane.io/v1beta1
+        kind: Input
+        rules:
+          - sequence:
+              - kubernetesCluster
+              - cniAddon
+              - nodeGroupPublic
+              - ebsCsiAddon

--- a/crossplane.yaml
+++ b/crossplane.yaml
@@ -42,3 +42,6 @@ spec:
     - function: xpkg.upbound.io/crossplane-contrib/function-auto-ready
       # renovate: datasource=github-releases depName=crossplane-contrib/function-auto-ready
       version: "v0.2.1"
+    - function: xpkg.upbound.io/crossplane-contrib/function-sequencer
+      # renovate: datasource=github-releases depName=crossplane-contrib/function-sequencer
+      version: "v0.1.2"

--- a/examples/functions.yaml
+++ b/examples/functions.yaml
@@ -18,5 +18,11 @@ metadata:
   name: crossplane-contrib-function-auto-ready
 spec:
   package: xpkg.upbound.io/crossplane-contrib/function-auto-ready:v0.2.1
-
+---
+apiVersion: pkg.crossplane.io/v1beta1
+kind: Function
+metadata:
+  name: crossplane-contrib-function-sequencer
+spec:
+  package: xpkg.upbound.io/crossplane-contrib/function-sequencer:v0.1.2
 


### PR DESCRIPTION

<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, use the below
line to indicate which issue your PR fixes, for example "Fixes #500":
-->

* Desired sequence Cluster -> CNIAddon -> NodeGroup -> ebsCsiAddon
* Use function-sequencer for reliable sequenced creation
* Add non-intrusive configuration example for vpc-cni
* Impementation for both standard P&T and KCL functions
* Fixes #12


I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

`make e2e`

Observed with `crossplane beta trace` that associated resources are sequenced properly during the XEKS instantiation.

Double-check with resource age timestamps.
```
k get cluster,addons,nodegroups
NAME                                                                      SYNCED   READY   EXTERNAL-NAME                                  AGE
cluster.eks.aws.upbound.io/configuration-aws-eks-7qr2g                    True     True    configuration-aws-eks-7qr2g                    27m
cluster.eks.aws.upbound.io/configuration-aws-eks-kcl-kubernetes-cluster   True     True    configuration-aws-eks-kcl-kubernetes-cluster   27m

NAME                                                               SYNCED   READY   EXTERNAL-NAME                                                     AGE
addon.eks.aws.upbound.io/configuration-aws-eks-kcl-cni-addon       True     True    configuration-aws-eks-kcl-kubernetes-cluster:vpc-cni              13m
addon.eks.aws.upbound.io/configuration-aws-eks-kcl-ebs-csi-addon   True     True    configuration-aws-eks-kcl-kubernetes-cluster:aws-ebs-csi-driver   10m
addon.eks.aws.upbound.io/configuration-aws-eks-n9bv8               True     True    configuration-aws-eks-7qr2g:vpc-cni                               16m
addon.eks.aws.upbound.io/configuration-aws-eks-xf5r8               True     True    configuration-aws-eks-7qr2g:aws-ebs-csi-driver                    13m

NAME                                                                      SYNCED   READY   EXTERNAL-NAME                                AGE
nodegroup.eks.aws.upbound.io/configuration-aws-eks-kcl-nodegroup-public   True     True    configuration-aws-eks-kcl-nodegroup-public   12m
nodegroup.eks.aws.upbound.io/configuration-aws-eks-vmwhl                  True     True    configuration-aws-eks-vmwhl                  15m
```
