### PR TITLE
Switch to new crossplane build module, consume KCL

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -30,6 +30,17 @@
       "depNameTemplate": "upbound/uptest",
     }, {
       "customType": "regex",
+      "description": "Bump Crossplane(UXP) version in the Makefile",
+      "fileMatch": ["^Makefile$"],
+      "matchStrings": [
+        "CROSSPLANE_VERSION = (?<currentValue>.*?)\\n"
+      ],
+      "datasourceTemplate": "github-releases",
+      "versioningTemplate": "regex:^v?(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)-up.1$",
+      "extractVersionTemplate": "^v(?<version>.*)$",
+      "depNameTemplate": "upbound/universal-crossplane",
+    }, {
+      "customType": "regex",
       "description": "Bump providers/functions/configurations in crossplane.yaml",
       "fileMatch": ["crossplane.yaml"],
       "matchStrings": [

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "build"]
 	path = build
-	url = https://github.com/upbound/build
+	url = https://github.com/crossplane/build


### PR DESCRIPTION


<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes

* Switch to `crossplane/build` module
* Consume KCL cli
* Adjust Makefile
* Prettify with local help

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

`make e2e` locally plus uptest below
