### PR TITLE
Update to v1 tags

### DIFF
--- a/crossplane.yaml
+++ b/crossplane.yaml
@@ -17,22 +17,15 @@ spec:
   dependsOn:
     - configuration: xpkg.upbound.io/upbound/configuration-aws-network
       # renovate: datasource=github-releases depName=upbound/configuration-aws-network
-      version: "v0.21.0"
+      version: "v0.22.0"
     - provider: xpkg.upbound.io/upbound/provider-helm
-      # renovate: datasource=github-releases depName=upbound/provider-helm
-      version: "v0.20.0"
+      version: "v0"
     - provider: xpkg.upbound.io/upbound/provider-kubernetes
-      # renovate: datasource=github-releases depName=upbound/provider-kubernetes
-      version: "v0.16.0"
-    - provider: xpkg.upbound.io/upbound/provider-aws-ec2
-      # renovate: datasource=github-releases depName=upbound/provider-aws
-      version: "v1.19.0"
+      version: "v0"
     - provider: xpkg.upbound.io/upbound/provider-aws-eks
-      # renovate: datasource=github-releases depName=upbound/provider-aws
-      version: "v1.19.0"
+      version: "v1"
     - provider: xpkg.upbound.io/upbound/provider-aws-iam
-      # renovate: datasource=github-releases depName=upbound/provider-aws
-      version: "v1.19.0"
+      version: "v1"
     - function: xpkg.upbound.io/crossplane-contrib/function-patch-and-transform
       # renovate: datasource=github-releases depName=crossplane-contrib/function-patch-and-transform
       version: "v0.8.0"


### PR DESCRIPTION
<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes

* Switch to v1 tag according to upcoming changes described in https://blog.upbound.io/upbound-official-packages-changes
* Disable renovate for provider version tag as it is going to be stable
* Consume configuration-aws-network dependency that is already v1 tag based


I have:

- [ ] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

uptest below
