### PR TITLE
Support setting accessConfig

### DIFF
--- a/apis/definition.yaml
+++ b/apis/definition.yaml
@@ -30,6 +30,20 @@ spec:
                     region:
                       type: string
                       description: Region is the region you'd like your resource to be created in.
+                    accessConfig:
+                      type: object
+                      properties:
+                        bootstrapClusterCreatorAdminPermissions:
+                          type: boolean
+                          description: Whether or not to bootstrap the access config values to the cluster. Default is false.
+                          default: false
+                        authenticationMode:
+                          type: string
+                          default: CONFIG_MAP
+                          enum:
+                            - CONFIG_MAP
+                            - API
+                            - API_AND_CONFIG_MAP
                     iam:
                       type: object
                       description: IAM configuration to connect as ClusterAdmin.

--- a/examples/eks-xr.yaml
+++ b/examples/eks-xr.yaml
@@ -7,6 +7,9 @@ spec:
     id: configuration-aws-eks
     region: us-west-2
     version: "1.27"
+    accessConfig:
+      authenticationMode: API_AND_CONFIG_MAP
+      bootstrapClusterCreatorAdminPermissions: true
     nodes:
       count: 1
       instanceType: t3.small

--- a/functions/xeks/main.k
+++ b/functions/xeks/main.k
@@ -3,11 +3,14 @@ import models.io.upbound.aws.eks.v1beta1 as eksv1beta1
 import models.io.upbound.aws.eks.v1beta2 as eksv1beta2
 import models.io.upbound.aws.iam.v1beta1 as iamv1beta1
 
-xrName = option("params")?.oxr?.metadata.name
-region = option("params")?.oxr?.spec.parameters.region or ""
-id = option("params")?.oxr?.spec.parameters.id or ""
-kubernetesVersion = option("params")?.oxr?.spec.parameters.version or ""
-uid = option("params")?.oxr?.metadata.uid or ""
+oxr = option("params").oxr
+
+xrName = oxr.metadata.name
+region = oxr.spec.parameters.region or ""
+id = oxr.spec.parameters.id or ""
+kubernetesVersion = oxr.spec.parameters.version or ""
+uid = oxr.metadata.uid or ""
+accessConfig = oxr.spec.parameters.accessConfig
 
 _metadata = lambda name: str -> any {
     {
@@ -16,8 +19,8 @@ _metadata = lambda name: str -> any {
 }
 
 _defaults = {
-    deletionPolicy = option("params")?.oxr?.spec.parameters.deletionPolicy or "Delete"
-    providerConfigRef.name = option("params")?.oxr?.spec.parameters.providerConfigName or "default"
+    deletionPolicy = oxr.spec.parameters.deletionPolicy or "Delete"
+    providerConfigRef.name = oxr.spec.parameters.providerConfigName or "default"
 }
 
 _items = []
@@ -61,6 +64,10 @@ _items += [
             forProvider = {
                 region = region
                 version = kubernetesVersion
+                accessConfig = {
+                    authenticationMode = oxr.spec.parameters.accessConfig.authenticationMode
+                    bootstrapClusterCreatorAdminPermissions = oxr.spec.parameters.accessConfig.bootstrapClusterCreatorAdminPermissions
+                }
                 roleArnSelector = {
                     matchControllerRef = True
                     matchLabels = {
@@ -100,7 +107,7 @@ if clusterSecurityGroupId:
         }
     ]
 
-connectionSecretNamespace = option("params")?.oxr?.spec.writeConnectionSecretToRef.namespace or "upbound-system"
+connectionSecretNamespace = oxr.spec.writeConnectionSecretToRef.namespace or "upbound-system"
 _items += [
     eksv1beta1.ClusterAuth{
         metadata = _metadata("kubeClusterAuth") # doesn't work with `kubernetesClusterAuth` or `kubernetesClusterAuthXXX` ???
@@ -155,8 +162,8 @@ _items += [
     }
 ]
 
-nodeCount = option("params")?.oxr?.spec.parameters.nodes.count or ""
-instanceType = option("params")?.oxr?.spec.parameters.nodes.instanceType or ""
+nodeCount = oxr.spec.parameters.nodes.count or ""
+instanceType = oxr.spec.parameters.nodes.instanceType or ""
 
 _items += [
     eksv1beta2.NodeGroup{
@@ -190,7 +197,7 @@ _items += [
     }
 ]
 
-principalArn = option("params")?.oxr?.spec?.parameters?.iam?.principalArn or False
+principalArn = oxr.spec?.parameters?.iam?.principalArn or False
 
 if principalArn:
     _items += [

--- a/tests/test-xeks/main.k
+++ b/tests/test-xeks/main.k
@@ -43,16 +43,6 @@ _items = [
                             "crossplane.io/composite" = "configuration-aws-eks"
                             role = "controlplane"
                         }
-                        ownerReferences = [
-                            {
-                                apiVersion = "aws.platform.upbound.io/v1alpha1"
-                                blockOwnerDeletion = True
-                                controller = True
-                                kind = "XEKS"
-                                name = "configuration-aws-eks"
-                                uid = ""
-                            }
-                        ]
                     }
                     spec = {
                         deletionPolicy = "Delete"
@@ -93,21 +83,14 @@ _items = [
                         labels = {
                             "crossplane.io/composite" = "configuration-aws-eks"
                         }
-                        ownerReferences = [
-                            {
-                                apiVersion = "aws.platform.upbound.io/v1alpha1"
-                                blockOwnerDeletion = True
-                                controller = True
-                                kind = "XEKS"
-                                name = "configuration-aws-eks"
-                                uid = ""
-                            }
-                        ]
                     }
                     spec = {
                         deletionPolicy = "Delete"
                         forProvider = {
                             region = "us-west-2"
+                            accessConfig = {
+                              authenticationMode = "API_AND_CONFIG_MAP"
+                            }
                             roleArnSelector = {
                                 matchControllerRef = True
                                 matchLabels = {
@@ -140,16 +123,6 @@ _items = [
                             "crossplane.io/composite" = "configuration-aws-eks"
                             role = "nodegroup"
                         }
-                        ownerReferences = [
-                            {
-                                apiVersion = "aws.platform.upbound.io/v1alpha1"
-                                blockOwnerDeletion = True
-                                controller = True
-                                kind = "XEKS"
-                                name = "configuration-aws-eks"
-                                uid = ""
-                            }
-                        ]
                     }
                     spec = {
                         deletionPolicy = "Delete"
@@ -194,16 +167,6 @@ _items = [
                             "crossplane.io/composite" = "configuration-aws-eks"
                         }
                         name = "configuration-aws-eks"
-                        ownerReferences = [
-                            {
-                                apiVersion = "aws.platform.upbound.io/v1alpha1"
-                                blockOwnerDeletion = True
-                                controller = True
-                                kind = "XEKS"
-                                name = "configuration-aws-eks"
-                                uid = ""
-                            }
-                        ]
                     }
                     spec = {
                         credentials = {
@@ -226,16 +189,6 @@ _items = [
                             "crossplane.io/composite" = "configuration-aws-eks"
                         }
                         name = "configuration-aws-eks"
-                        ownerReferences = [
-                            {
-                                apiVersion = "aws.platform.upbound.io/v1alpha1"
-                                blockOwnerDeletion = True
-                                controller = True
-                                kind = "XEKS"
-                                name = "configuration-aws-eks"
-                                uid = ""
-                            }
-                        ]
                     }
                     spec = {
                         credentials = {
@@ -257,16 +210,6 @@ _items = [
                         labels = {
                             "crossplane.io/composite" = "configuration-aws-eks"
                         }
-                        ownerReferences = [
-                            {
-                                apiVersion = "aws.platform.upbound.io/v1alpha1"
-                                blockOwnerDeletion = True
-                                controller = True
-                                kind = "XEKS"
-                                name = "configuration-aws-eks"
-                                uid = ""
-                            }
-                        ]
                     }
                     spec = {
                         deletionPolicy = "Delete"


### PR DESCRIPTION
<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes

Support setting accessConfig is required for migrating configuration-aws-eks-karpenter to new upbound devex.  See following error message
```
    message: 'observe failed: failed to observe the resource: [{0 reading EKS Access
      Entry (configuration-aws-eks-karpenter-kq4mx:arn:aws:iam::609897127049:role/configuration-aws-eks-karpenter-82f58):
      operation error EKS: DescribeAccessEntry, https response error StatusCode: 400,
      RequestID: 2b16e8be-a246-40ff-9505-7cd03feef6bf, InvalidRequestException: The
      cluster''s authentication mode must be set to one of [API, API_AND_CONFIG_MAP]
      to perform this operation.  []}]'
```

default is `CONFIG_MAP`

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, use the below
line to indicate which issue your PR fixes, for example "Fixes #500":
-->

Fixes #

I have:

- [ ] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

```bash
$> up test run tests/test-xeks/
  ✓   Parsing tests
  ✓   Checking dependencies
  ✓   Generating language schemas
  ✓   Checking dependencies
  ✓   Generating language schemas
  ✓   Building functions
  ✓   Building configuration package
  ✓   Pushing embedded functions to local daemon
  ✓   Assert
 SUCCESS
 SUCCESS  Tests Summary:
 SUCCESS  ------------------
 SUCCESS  Total Tests Executed: 1
 SUCCESS  Passed tests:         1
 SUCCESS  Failed tests:         0
```
<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change. Consider pasting snippets
with the commands or configurations you used to test, in case you or a reviewer
needs to repeat the test in future.
-->
