### PR TITLE
feat(bump): bump eks version and update ebs addon

### DIFF
--- a/apis/definition.yaml
+++ b/apis/definition.yaml
@@ -67,14 +67,10 @@ spec:
                       description: Kubernetes version
                       type: string
                       enum:
+                        - "1.33"
+                        - "1.32"
                         - "1.31"
-                        - "1.30"
-                        - "1.29"
-                        - "1.28"
-                        - "1.27"
-                        - "1.26"
-                        - "1.25"
-                      default: "1.31"
+                      default: "1.32"
                     nodes:
                       type: object
                       description: EKS node configuration parameters.

--- a/examples/eks-xr.yaml
+++ b/examples/eks-xr.yaml
@@ -6,7 +6,6 @@ spec:
   parameters:
     id: configuration-aws-eks
     region: us-west-2
-    version: "1.27"
     accessConfig:
       authenticationMode: API_AND_CONFIG_MAP
       bootstrapClusterCreatorAdminPermissions: true

--- a/functions/xeks/main.k
+++ b/functions/xeks/main.k
@@ -289,6 +289,7 @@ if ready(get(ocds, "nodeGroupPublic", "")) or exists("aws-ebs-csi-driver-addon")
                     region = region
                     addonName = "aws-ebs-csi-driver"
                     clusterNameSelector.matchControllerRef = True
+                    configurationValues = '{"defaultStorageClass": {"enabled": true}}'
                 }
             }
         }

--- a/tests/e2etest-xeks/main.k
+++ b/tests/e2etest-xeks/main.k
@@ -18,7 +18,6 @@ _items = [
                         parameters = {
                             id = "configuration-aws-eks"
                             region = "us-west-2"
-                            version = "1.27"
                             accessConfig: {
                                 authenticationMode: "CONFIG_MAP"
                                 bootstrapClusterCreatorAdminPermissions: True

--- a/tests/test-xeks-cluster-security-group/main.k
+++ b/tests/test-xeks-cluster-security-group/main.k
@@ -14,7 +14,6 @@ _items = [
                         parameters: {
                             id: "configuration-aws-eks"
                             region: "us-west-2"
-                            version: "1.27"
                             nodes: {
                                 count: 1
                                 instanceType: "t3.small"
@@ -114,7 +113,6 @@ _items = [
                     parameters: {
                         id: "configuration-aws-eks"
                         region: "us-west-2"
-                        version: "1.27"
                         nodes: {
                             count: 1
                             instanceType: "t3.small"

--- a/tests/test-xeks-iam/main.k
+++ b/tests/test-xeks-iam/main.k
@@ -13,7 +13,6 @@ _items = [
                         parameters: {
                             id: "configuration-aws-eks"
                             region: "us-west-2"
-                            version: "1.27"
                             nodes: {
                                 count: 1
                                 instanceType: "t3.small"
@@ -101,7 +100,6 @@ _items = [
                     parameters: {
                         id: "configuration-aws-eks"
                         region: "us-west-2"
-                        version: "1.27"
                         nodes: {
                             count: 1
                             instanceType: "t3.small"

--- a/tests/test-xeks-sequence/resources.k
+++ b/tests/test-xeks-sequence/resources.k
@@ -28,7 +28,6 @@ _kubernetesCluster = eksv1beta2.Cluster {
                     role = "controlplane"
                 }
             }
-            version = "1.27"
             vpcConfig = {
                 endpointPrivateAccess = True
                 subnetIdSelector = {
@@ -57,7 +56,6 @@ _xr = platformawsv1alpha1.XEKS {
                 instanceType = "t3.small"
             }
             region = "us-west-2"
-            version = "1.27"
         }
         writeConnectionSecretToRef = {
             name = "configuration-aws-eks-kubeconfig"


### PR DESCRIPTION
<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes
- remove the following EKS Version
- "1.30", "1.29" ,"1.28", "1.27" ,"1.26" , "1.25"
- switch default to "1.32"
- added "1.32", "1.33"

- added to ebs addon
- {"defaultStorageClass": {"enabled": true}}

` Starting with 1.30, Amazon EKS no longer includes the default annotation on the gp2 StorageClass resource applied to newly created clusters. This has no impact if you are referencing this storage class by name. You must take action if you were relying on having a default StorageClass in the cluster. You should reference the StorageClass by the name gp2. Alternatively, you can deploy the Amazon EBS recommended default storage class by setting the defaultStorageClass.enabled parameter to true when installing version 1.31.0 or later of the aws-ebs-csi-driver add-on.`
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, use the below
line to indicate which issue your PR fixes, for example "Fixes #500":
-->

Fixes #

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

```
PASS
2025/06/20 20:39:22 Tests Summary:
2025/06/20 20:39:22 - Passed: 1
2025/06/20 20:39:22 - Failed: 0
2025/06/20 20:39:22 - Skipped: 0
SUCCESS: 
SUCCESS: Tests Summary:
SUCCESS: ------------------
SUCCESS: Total Tests Executed: 1
SUCCESS: Passed tests:         1
SUCCESS: Failed tests:         0
```

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change. Consider pasting snippets
with the commands or configurations you used to test, in case you or a reviewer
needs to repeat the test in future.
-->
