### PR TITLE
add 1.35 k8s version and fixing version parameter

### DIFF
--- a/apis/eks/definition.yaml
+++ b/apis/eks/definition.yaml
@@ -73,6 +73,7 @@ spec:
                     description: Kubernetes version
                     type: string
                     enum:
+                    - "1.35"
                     - "1.34"                      
                     - "1.33"
                     - "1.32"

--- a/functions/eks/main.k
+++ b/functions/eks/main.k
@@ -93,7 +93,7 @@ _items += [
         spec: _defaults | {
             forProvider = {
                 region = params.region
-                version = params.kubernetesVersion
+                version = params.version
                 accessConfig = {
                     authenticationMode = params.accessConfig.authenticationMode
                     bootstrapClusterCreatorAdminPermissions = params.accessConfig.bootstrapClusterCreatorAdminPermissions


### PR DESCRIPTION
<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes
Fixed incorrect parameter reference for k8s cluster version and adding support for 1.35. Fixes #148 

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested
```up test run tests/*
✓ Parsing tests
✓ Collecting resources
✓ Generating language schemas
✓ Checking dependencies
✓ Building functions
✓ Building configuration package
✓ Pushing embedded functions to local daemon
✓ Assert test-eks-cluster-security-group
✓ Assert eks-iam
✓ Assert sequence-0
✓ Assert sequence-0-cluster-ready
✓ Assert sequence-0-cluster-auth-ready
✓ Assert sequence-0-vpc-cni-addon-ready
✓ Assert sequence-0-pod-identity-and-nodegroup-ready
🙌
🙌 Tests Summary:
🙌 ------------------
🙌 Total Tests Executed: 7
🙌 Passed tests:         7
🙌 Failed tests:         0
```
