### PR TITLE
feat: surface OIDC issuer, cluster ARN, and node instance type on status

### DIFF
--- a/functions/eks/main.k
+++ b/functions/eks/main.k
@@ -418,12 +418,31 @@ _items += [{
         data: {}
 }]
 
+# Read the observed Cluster / NodeGroup atProvider blocks (None until they
+# sync). Surfacing these on the EKS status lets higher-level configurations
+# (e.g. configuration-aws-ctp) read the OIDC issuer, cluster ARN and running
+# node instance type from the EKS XR instead of composing their own
+# observe-only Cluster / NodeGroup managed resources.
+_clusterAtProvider = _ocds["kubernetesCluster"]?.Resource?.status?.atProvider
+_ngAtProvider = _ocds["nodeGroupPublic"]?.Resource?.status?.atProvider
+
+_identity = _clusterAtProvider?.identity or []
+_oidcList = (_identity[0]?.oidc or []) if len(_identity) > 0 else []
+_oidcIssuerUrl = (_oidcList[0]?.issuer or "") if len(_oidcList) > 0 else ""
+
+_ngInstanceTypes = _ngAtProvider?.instanceTypes or []
+
 # Update the dxr status.
 _dxr = _dxr | {
     status: {
         eks: {
             clusterName: _ocds["kubernetesCluster"]?.Resource?.metadata?.name
-            nodeGroupArn: _ocds["nodeGroupPublic"]?.Resource?.status?.atProvider?.arn
+            clusterArn: _clusterAtProvider?.arn
+            oidcIssuerUrl: _oidcIssuerUrl
+            nodeGroupArn: _ngAtProvider?.arn
+            nodeGroup: {
+                instanceType: _ngInstanceTypes[0] if len(_ngInstanceTypes) > 0 else ""
+            }
         }
     }
 }

--- a/functions/eks/main.k
+++ b/functions/eks/main.k
@@ -14,7 +14,6 @@ dcds = option("params").dcds # desired composed resources
 params = oxr.spec.parameters
 
 xrName = oxr.metadata.name
-uid = oxr.metadata.uid or ""
 
 _metadata = lambda name: str -> any {
     {
@@ -147,7 +146,7 @@ if ready(get(_ocds, "kubernetesCluster", "")) or exists("kubernetesClusterAuth")
                     clusterNameSelector.matchControllerRef = True
                 }
                 writeConnectionSecretToRef = {
-                    name = "{}-ekscluster".format(uid)
+                    name = "{}-ekscluster".format(params.id)
                 }
             }
         }
@@ -377,7 +376,7 @@ _items += [
         }
         spec.credentials = {
             secretRef = {
-                name = "{}-ekscluster".format(uid)
+                name = "{}-ekscluster".format(params.id)
                 namespace = oxr.metadata.namespace
                 key = "kubeconfig"
             }
@@ -398,7 +397,7 @@ _items += [
         }
         spec.credentials = {
             secretRef = {
-                name = "{}-ekscluster".format(uid)
+                name = "{}-ekscluster".format(params.id)
                 namespace = oxr.metadata.namespace
                 key = "kubeconfig"
             }

--- a/tests/test-eks-cluster-security-group/main.k
+++ b/tests/test-eks-cluster-security-group/main.k
@@ -65,6 +65,8 @@ _items = [
                             "crossplane.io/composition-resource-name" = "kubernetesCluster"
                         }
                         generateName = "configuration-aws-eks-"
+                        name = "configuration-aws-eks-kubernetescluster"
+                        namespace = "default"
                         labels = {
                             "crossplane.io/composite" = "configuration-aws-eks"
                         }

--- a/tests/test-eks-sequence/main.k
+++ b/tests/test-eks-sequence/main.k
@@ -66,6 +66,10 @@ _test2 = metav1alpha1.CompositionTest {
     spec.observedResources: [
         eksv1beta1.Cluster {
             **resources._kubernetesCluster
+            metadata: {
+                name = "configuration-aws-eks-cluster"
+                namespace = "default"
+            }
             status: {
                 atProvider:{
                     id: "test-kubernetes-cluster"
@@ -85,6 +89,10 @@ _test3 = metav1alpha1.CompositionTest {
     spec.observedResources: _test2.spec.observedResources + [
         eksv1beta1.ClusterAuth {
             **resources._kubernetesClusterAuth
+            metadata: {
+                name = "configuration-aws-eks-clusterauth"
+                namespace = "default"
+            }
             status: {
                 atProvider: {
                     lastRefreshTime: "12345"
@@ -104,6 +112,10 @@ _test4 = metav1alpha1.CompositionTest {
     spec.observedResources: _test3.spec.observedResources + [
         eksv1beta1.Addon {
             **resources._vpcCniAddon
+            metadata: {
+                name = "configuration-aws-eks-vpccni"
+                namespace = "default"
+            }
             status: {
                 atProvider:{
                     id: "test-vpc-cni-addon"
@@ -123,6 +135,10 @@ _test5 = metav1alpha1.CompositionTest {
     spec.observedResources: _test4.spec.observedResources + [
         iamv1beta1.Role {
             **resources._ebsCSIDriverRole
+            metadata: {
+                name = "configuration-aws-eks-ebscsidriverrole"
+                namespace = "default"
+            }
             status: {
                 atProvider:{
                     arn: "arn:aws:iam::123456789012:role/test-ebs-csi-driver-role"
@@ -132,6 +148,10 @@ _test5 = metav1alpha1.CompositionTest {
         }
         eksv1beta1.PodIdentityAssociation {
             **resources._ebsCSIDriverPodIdentityAssociation
+            metadata: {
+                name = "configuration-aws-eks-ebscsipodidentity"
+                namespace = "default"
+            }
             status: {
                 atProvider:{
                     associationId: "test-pod-identity-association"
@@ -141,6 +161,10 @@ _test5 = metav1alpha1.CompositionTest {
         }
         eksv1beta1.NodeGroup {
             **resources._nodeGroupPublic
+            metadata: {
+                name = "configuration-aws-eks-nodegrouppublic"
+                namespace = "default"
+            }
             status: {
                 atProvider:{
                     id: "test-nodegroup-public"

--- a/tests/test-eks-sequence/resources.k
+++ b/tests/test-eks-sequence/resources.k
@@ -164,7 +164,7 @@ _providerConfigHelm = helmv1beta1.ProviderConfig {
         credentials = {
             secretRef = {
                 key = "kubeconfig"
-                name = "-ekscluster"
+                name = "configuration-aws-eks-ekscluster"
                 namespace = "default"
             }
             source = "Secret"
@@ -186,7 +186,7 @@ _providerConfigKubernetes = kubernetesv1alpha1.ProviderConfig {
         credentials = {
             secretRef = {
                 key = "kubeconfig"
-                name = "-ekscluster"
+                name = "configuration-aws-eks-ekscluster"
                 namespace = "default"
             }
             source = "Secret"

--- a/tests/test-eks-sequence/resources.k
+++ b/tests/test-eks-sequence/resources.k
@@ -221,7 +221,7 @@ _kubernetesClusterAuth = eksv1beta1.ClusterAuth {
             name = "default"
         }
         writeConnectionSecretToRef = {
-            name = "-ekscluster"
+            name = "configuration-aws-eks-ekscluster"
         }
     }
 }


### PR DESCRIPTION
### Description of your changes

- Populate `status.eks.oidcIssuerUrl`, `.clusterArn`, and `.nodeGroup.instanceType` (alongside the existing `clusterName`/`nodeGroupArn`) from the observed `Cluster` and `NodeGroup` MRs. 
This lets higher-level configurations such as `configuration-aws-ctp` read cluster metadata from the EKS XR instead of composing their own observe-only `Cluster`/`NodeGroup` resources.

- Fixed composition tests: name kubeconfig connection secret by id instead of uid + add name+namespace to observed resources for up v0.50.0