### PR TITLE
feat: brownfield import for existing EKS clusters

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,10 +85,17 @@ lists the missing keys — a guardrail against a half-imported, half-created sta
   - **Addon `configurationValues`**, **`vpcConfig.endpointPrivateAccess`**, and any other field the
     composition fixes unconditionally.
 
-Scalar lists (subnet IDs, policy ARNs, ...) are compared **order-insensitively**, so a cloud that returns
-the same set in a different order does not register as a change. A `sideEffects` entry for an *immutable*
-field is a change the provider will **refuse** at commit (its refuse-to-replace guardrail) rather than
-apply — the report does not try to predict which fields those are.
+The diff normalizes two common sources of false positives, generically (no field-name list):
+
+- **Scalar lists** (subnet IDs, policy ARNs, ...) are compared **order-insensitively**, so a cloud that
+  returns the same set in a different order does not register as a change.
+- **JSON-string fields** (IAM `assumeRolePolicy`, addon `configurationValues`, ...) are compared
+  **semantically** — parsed and compared as data — so whitespace and key-order differences between the
+  composition's declaration and the cloud's serialization do not register. A string is detected as JSON
+  structurally (it opens like a JSON object), never by field name.
+
+A `sideEffects` entry for an *immutable* field is a change the provider will **refuse** at commit (its
+refuse-to-replace guardrail) rather than apply — the report does not try to predict which fields those are.
 
 ### Existing / remote network (`spec.parameters.network`)
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,105 @@ The configuration can be tested using:
 - `up test run tests/*` to run composition tests in `tests/test-eks/`
 - `up test run tests/* --e2e` to run end-to-end tests in `tests/e2etest-eks/`
 
+## Brownfield import
+
+EKS clusters that already exist in AWS (created via the console, Terraform, `eksctl`, etc.) can be
+adopted by this composition **without recreating or mutating them**, using the `import` block on the
+`EKS` XR (see [examples/eks/eks-import-xr.yaml](/examples/eks/eks-import-xr.yaml)).
+
+### How it works
+
+1. **Observe** — set `spec.parameters.import.resources` to a map of composition resource key →
+   `crossplane.io/external-name` of the existing AWS resource, with `import.commit: false`. Every managed
+   resource is rendered **observe-only** (`["Observe","LateInitialize"]`) and pinned to the given external
+   name, so nothing in AWS is changed. The composition publishes a report on `status.import` that is a
+   **generic diff of each resource's `spec.forProvider` (the composition's desired state, the source of
+   truth) against its live `status.atProvider`** — i.e. everything committing *would* change. There is no
+   curated field list; any field the composition declares that the cloud disagrees with shows up. Each
+   change is classified (see below) into `drift` (reconcilable via parameters) and `sideEffects`
+   (everything else), with `driftCount` and `sideEffectCount` totals.
+2. **Reconcile** — adjust `spec.parameters` (version, instance type, subnets, ...) until
+   `status.import.driftCount` is `0` (or covers only changes you intend to apply), then **review
+   `status.import.sideEffects`**: these are changes with no parameter knob that committing will make anyway
+   (tag rewrites, role policies, addon config, ...). Accept them before continuing.
+3. **Commit** — set `import.commit: true`. Management policies switch to `["*"]`, taking full control and
+   converging the mutable configuration to what the composition declares. The provider **refuses any change
+   that would require replacing a resource** (its built-in guardrail), so immutable / create-time fields are
+   protected — you do not have to predict them.
+4. **Finalize** — remove the `import` block. The external names persist on the managed resources, so the
+   cluster stays adopted under normal management. Keep `spec.parameters.network` (see below) — it is a
+   normal parameter, not part of import.
+
+If `import.resources` is non-empty but any importable resource the composition would render is missing an
+external name, the render is **blocked** (no managed resources are emitted) and `status.import.missing`
+lists the missing keys — a guardrail against a half-imported, half-created state.
+
+### The report: `drift` vs `sideEffects`
+
+`status.import.resources.<key>` carries two lists, both produced by the same generic `forProvider` ↔
+`atProvider` diff:
+
+- **`drift`** (summed into `driftCount`) — changes backed by an editable XR parameter, so you can
+  reconcile them to zero before committing: currently `version`, `accessConfig.authenticationMode`,
+  node `instanceTypes`, `scalingConfig.desiredSize`, and `subnetIds`. Each entry is
+  `{field, desired, observed}`.
+- **`sideEffects`** (summed into `sideEffectCount`) — everything else the diff finds: changes committing
+  will make that you **cannot** influence through parameters. These are informational but important; review
+  them before setting `commit: true`. Common ones:
+  - **Tag rewrites.** The provider reconciles each resource's tag set to `forProvider`, which is the
+    auto-injected `crossplane-*` management tags. Tags the original tool added (e.g. `eksctl` /
+    cost-allocation tags) are **removed** on commit (shown as an entry with only `observed`), and the
+    `crossplane-*` tags are **added** (shown with only `desired`). Reported per key as `tags[<key>]`.
+  - **IAM role policies / trust** (`managedPolicyArns`, `assumeRolePolicy`) — the composition declares its
+    own role shape; committing conforms the adopted role to it, which may add/remove managed policies or
+    rewrite the trust relationship.
+  - **Addon `configurationValues`**, **`vpcConfig.endpointPrivateAccess`**, and any other field the
+    composition fixes unconditionally.
+
+Scalar lists (subnet IDs, policy ARNs, ...) are compared **order-insensitively**, so a cloud that returns
+the same set in a different order does not register as a change. A `sideEffects` entry for an *immutable*
+field is a change the provider will **refuse** at commit (its refuse-to-replace guardrail) rather than
+apply — the report does not try to predict which fields those are.
+
+### Existing / remote network (`spec.parameters.network`)
+
+By default the composition selects subnets from a `Network` it composes (label-based, greenfield). A
+brownfield cluster lives in a VPC the composition did not create, so you must tell it the real subnets via
+`spec.parameters.network`:
+
+- `subnetIds` — the cluster control-plane ENI subnets (should span ≥2 AZs).
+- `nodeSubnetIds` — the worker-node subnets (defaults to `subnetIds`). **Node group subnets are immutable**,
+  so these must match the existing node group exactly or commit will (correctly) refuse to replace it.
+
+This is also the mechanism for running greenfield in a pre-existing VPC. The VPC is derived from the subnets
+and the EKS cluster security group is managed automatically, so neither needs to be supplied.
+
+### External-name formats
+
+The cluster name for NodeGroup and PodIdentityAssociation comes from the composition's
+`clusterNameSelector`, so their external-name is the **child id only** — do not prefix the cluster name.
+
+| Key | AWS resource | external-name format |
+|-----|--------------|----------------------|
+| `kubernetesCluster` | EKS Cluster | `<cluster-name>` |
+| `controlplaneRole`, `nodegroupRole`, `ebsCSIDriverRole` | IAM Role | `<role-name>` |
+| `nodeGroupPublic` | EKS NodeGroup | `<nodegroup-name>` |
+| `vpcCniAddon`, `ebsCsiAddon`, `podIdentityAgentAddon` | EKS Addon | `<cluster-name>:<addon-name>` |
+| `ebsCSIDriverPodIdentityAssociation` | EKS PodIdentityAssociation | `<association-id>` (e.g. `a-xxxxxxxxxxxxxxxxx`) |
+| `accessEntry` | EKS AccessEntry | `<cluster-name>:<principal-arn>` |
+| `accessPolicyAssociation` | EKS AccessPolicyAssociation | `<cluster-name>#<principal-arn>#<policy-arn>` |
+
+`accessEntry`/`accessPolicyAssociation` are only required when `spec.parameters.iam.principalArn` is set.
+
+### Notes / boundaries
+
+- **ClusterAuth** is a token generator with no importable external state; it always runs under normal
+  management (`["*"]`) even during import.
+- **Create-time-only fields** (e.g. `bootstrapSelfManagedAddons`) cannot be changed on an adopted cluster
+  without recreating it. The composition does not try to conform them; the provider's refuse-to-replace
+  guardrail protects the resource and surfaces a benign condition. Adopt for day-2 management, not for
+  re-architecting immutable topology.
+
 ## Next steps
 
 This repository serves as a foundational step. To enhance your configuration, consider:

--- a/apis/eks/definition.yaml
+++ b/apis/eks/definition.yaml
@@ -30,6 +30,54 @@ spec:
                   region:
                     type: string
                     description: Region is the region you'd like your resource to be created in.
+                  network:
+                    type: object
+                    description: >
+                      Existing/remote network placement. When subnetIds is set, the cluster and node
+                      group are placed in these existing subnets directly instead of selecting subnets
+                      from a Network composed by this platform (the default greenfield behavior). Set this
+                      to run in a pre-existing VPC or to adopt a brownfield cluster (see spec.parameters.import).
+                    properties:
+                      subnetIds:
+                        type: array
+                        items:
+                          type: string
+                        description: >
+                          Subnet IDs for the EKS cluster control-plane ENIs (should span >=2 AZs).
+                      nodeSubnetIds:
+                        type: array
+                        items:
+                          type: string
+                        description: >
+                          Subnet IDs for worker nodes. Defaults to subnetIds when unset. EKS node group
+                          subnets are immutable, so for import these must match the existing node group.
+                  import:
+                    type: object
+                    description: >
+                      Brownfield import controls. Use to adopt EKS resources that already exist in AWS
+                      (created out-of-band) without recreating them. Lifecycle: (1) set resources with
+                      commit=false to observe existing infrastructure and review status.import drift;
+                      (2) reconcile parameters until drift is empty; (3) set commit=true to take full
+                      management; (4) drop this block once the migration is complete.
+                    properties:
+                      resources:
+                        type: object
+                        additionalProperties:
+                          type: string
+                        description: >
+                          Map of composition resource key -> crossplane.io/external-name of the existing
+                          AWS resource. When non-empty, ALL importable resources the composition renders
+                          must be present, otherwise the render is blocked (see status.import.missing).
+                          Keys: controlplaneRole, nodegroupRole, ebsCSIDriverRole, kubernetesCluster,
+                          nodeGroupPublic, vpcCniAddon, ebsCsiAddon, podIdentityAgentAddon,
+                          ebsCSIDriverPodIdentityAssociation, accessEntry, accessPolicyAssociation.
+                      commit:
+                        type: boolean
+                        default: false
+                        description: >
+                          When false (default) every managed resource is set to observe-only
+                          (["Observe","LateInitialize"]) so nothing in AWS is mutated. When true the
+                          management policies switch to ["*"] to complete the migration.
                   accessConfig:
                     type: object
                     properties:
@@ -106,6 +154,13 @@ spec:
               properties:
                 eks:
                   description: Freeform field containing status information for eks
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+                import:
+                  description: >
+                    Import phase report. Contains the resolved external names, any missing keys that
+                    block the render, and a per-resource drift report (composition-desired forProvider
+                    vs live status.atProvider) that shows what committing would change.
                   type: object
                   x-kubernetes-preserve-unknown-fields: true
               type: object

--- a/examples/eks/eks-import-xr.yaml
+++ b/examples/eks/eks-import-xr.yaml
@@ -1,0 +1,70 @@
+# Brownfield import example.
+#
+# Adopts an EKS cluster (and its nodegroup, roles, addons, pod-identity association)
+# that already exists in AWS into this composition WITHOUT recreating anything.
+#
+# Lifecycle:
+#   1. Apply this XR as-is (commit: false). Every managed resource is created
+#      observe-only ("Observe","LateInitialize") and pinned to the external names
+#      below. Nothing in AWS is mutated. Watch `status.import`: a generic diff of
+#      the composition's desired forProvider vs the live atProvider, split into
+#      `drift` (reconcilable via params, -> driftCount) and `sideEffects`
+#      (committing does these anyway: tag rewrites, role policies, ... -> sideEffectCount).
+#   2. Reconcile spec.parameters (version, instanceType, ...) until
+#      `status.import.driftCount` is 0 for anything you care about, and review
+#      `status.import.sideEffects` so you accept what else commit will change. On
+#      commit the provider refuses any change that would require REPLACING a
+#      resource, so immutable/create-time fields are protected regardless.
+#   3. Set import.commit: true to take full management ("*").
+#   4. Once healthy, delete the entire `import` block. External names persist on the
+#      managed resources, so the cluster stays adopted. Keep `network` (below) - it is
+#      a normal parameter, not part of import.
+#
+# Replace every <...> with the real value of the existing AWS resource.
+apiVersion: aws.platform.upbound.io/v1alpha1
+kind: EKS
+metadata:
+  name: imported-eks
+  namespace: default
+spec:
+  parameters:
+    id: imported-eks
+    region: us-west-2
+    accessConfig:
+      authenticationMode: API_AND_CONFIG_MAP
+      bootstrapClusterCreatorAdminPermissions: true
+    version: "1.33"
+    nodes:
+      count: 1
+      instanceType: t3.small
+    # Existing network placement. Required for import: the cluster lives in a VPC this
+    # composition did not create, so give it the real subnets. Node group subnets are
+    # immutable, so nodeSubnetIds MUST match the existing node group exactly.
+    network:
+      subnetIds:            # cluster control-plane ENI subnets (all AZs)
+        - <subnet-id-a>
+        - <subnet-id-b>
+        - <subnet-id-c>
+      nodeSubnetIds:        # worker-node subnets (subset the node group actually uses)
+        - <subnet-id-a>
+        - <subnet-id-b>
+        - <subnet-id-c>
+    import:
+      commit: false
+      resources:
+        # eks Cluster external-name = <cluster-name>
+        kubernetesCluster: <cluster-name>
+        # iam Role external-name = <role-name>
+        controlplaneRole: <controlplane-role-name>
+        nodegroupRole: <nodegroup-role-name>
+        ebsCSIDriverRole: <ebs-csi-driver-role-name>
+        # eks NodeGroup external-name = <nodegroup-name> ONLY (cluster comes from the
+        # composition's clusterNameSelector - do NOT prefix the cluster name).
+        nodeGroupPublic: <nodegroup-name>
+        # eks Addon external-name = <cluster-name>:<addon-name>
+        vpcCniAddon: <cluster-name>:vpc-cni
+        ebsCsiAddon: <cluster-name>:aws-ebs-csi-driver
+        podIdentityAgentAddon: <cluster-name>:eks-pod-identity-agent
+        # eks PodIdentityAssociation external-name = <association-id> ONLY (e.g. a-xxxxxxxxxxxxxxxxx;
+        # cluster comes from the composition's clusterNameSelector).
+        ebsCSIDriverPodIdentityAssociation: <association-id>

--- a/functions/eks/importkit.k
+++ b/functions/eks/importkit.k
@@ -1,0 +1,183 @@
+"""
+Brownfield import kit.
+
+A generic, provider-agnostic engine for adopting pre-existing cloud resources
+into a Crossplane v2 composition. It works purely on observed composed resources:
+each resource's spec.forProvider is treated as the composition's desired state
+(the source of truth) and status.atProvider as live cloud state. It therefore
+carries no provider-schema dependency and can be reused by any composition.
+
+The composition supplies a small spec - which resources are importable, their
+composition-resource-names, which leaf fields map to editable parameters, and
+which keys are required - and this module computes the full set of changes a
+commit would make, split into reconcilable `drift` and unreconcilable
+`sideEffects`.
+"""
+
+import regex
+import json
+
+schema Change:
+    """A single field-level difference between desired (forProvider) and live (atProvider) state.
+
+    An absent `desired` means the field/tag would be removed on commit; an absent
+    `observed` means it would be added.
+    """
+    field: str
+    desired?: any
+    observed?: any
+
+# ---------------------------------------------------------------------------
+# Private helpers
+# ---------------------------------------------------------------------------
+
+# Dot-separated path getter with default (mirrors the composition's own get()).
+_get = lambda x: any, y: str, d: any -> any {
+    p = regex.split(y, "\.")
+    c = p[0]
+    rest = ".".join(p[1::])
+    x[c] if len(p) == 1 and c in x else d if c not in x else _get(x[c], rest, d)
+}
+
+# Scalar / set-like list handling: AWS set-like fields (subnetIds,
+# managedPolicyArns, ...) come back from the cloud in a different order than the
+# composition declares them, which is not a real change - compare them as sets.
+_isScalar = lambda v: any -> bool {
+    typeof(v) in ["str", "int", "float", "bool"]
+}
+_scalarList = lambda v: any -> bool {
+    typeof(v) == "list" and (all e in v { _isScalar(e) })
+}
+_sameSet = lambda a: any, b: any -> bool {
+    len(a) == len(b) and (all e in a { e in b }) and (all e in b { e in a })
+}
+
+# JSON-string handling: many cloud fields (IAM assumeRolePolicy, addon
+# configurationValues, ...) are JSON serialized into a string; the composition
+# declares them pretty-printed / in one key order while the cloud returns them
+# compacted / reordered. Detection is structural (no field-name list): a string
+# is treated as JSON only if it opens like a JSON object - `{"...` or `{}` - which
+# also rejects lookalikes such as Go templates (`{{ ... }}`). `[`-strings are
+# intentionally NOT treated as JSON (e.g. `[INFO] ...` is not an array) so
+# json.decode never sees non-JSON (KCL cannot recover from a decode error).
+_looksJson = lambda s: str -> bool {
+    regex.match(s, "^\\s*\\{\\s*(\"|\\})")
+}
+# Semantic equality via decode; KCL dict equality is key-order independent, so
+# this collapses whitespace and key-order differences.
+_jsonEqual = lambda a: str, b: str -> bool {
+    json.decode(a) == json.decode(b)
+}
+
+# Crossplane cross-resource wiring / provider-computed mirrors: never real cloud
+# state, so skipping them avoids false positives.
+_skipKey = lambda k: str -> bool {
+    k.endswith("Ref") or k.endswith("Refs") or k.endswith("Selector") or k == "tagsAll"
+}
+
+# Bidirectional diff for open-keyed maps (tags): removals (live but not desired ->
+# committing strips them) and additions/updates (desired but not live / changed).
+_mapDiff = lambda fp: any, ap: any, path: str -> [any] {
+    _rm = [{field = "{}[{}]".format(path, k), observed = ap[k]} for k in ap if k not in fp]
+    _ch = [{field = "{}[{}]".format(path, k), desired = fp[k], observed = (ap[k] if k in ap else Undefined)} for k in fp if (k not in ap or ap[k] != fp[k])]
+    _rm + _ch
+}
+
+# Deep diff driven by desired (forProvider). Recurses into nested objects, but
+# only descends when the observed side is also an object - an absent observed
+# subtree means the cloud does not report it, which is not a committable change.
+_diffField = lambda k: str, dv: any, ov: any, path: str -> [any] {
+    _jsonPair = typeof(dv) == "str" and typeof(ov) == "str" and _looksJson(dv) and _looksJson(ov)
+    _listPair = _scalarList(dv) and _scalarList(ov)
+    _valueChanged = (not _jsonEqual(dv, ov)) if _jsonPair else ((not _sameSet(dv, ov)) if _listPair else (dv != ov))
+    _leafChanged = ov != Undefined and ov != None and _valueChanged
+    _leaf = [{field = path, desired = dv, observed = ov}] if _leafChanged else []
+    _obj = _deepDiff(dv, ov, path) if (typeof(dv) == "dict" and typeof(ov) == "dict") else _leaf
+    _mapDiff(dv or {}, ov or {}, path) if k == "tags" else _obj
+}
+_deepDiff = lambda desired: any, observed: any, prefix: str -> [any] {
+    sum([
+        _diffField(k, desired[k], (observed[k] if (typeof(observed) == "dict" and k in observed) else Undefined), (prefix + "." + k if prefix != "" else k))
+        for k in desired if not _skipKey(k)
+    ], [])
+}
+
+_isReconcilable = lambda field: str, reconcilable: [str] -> bool {
+    any p in reconcilable { field.endswith(p) }
+}
+
+# Full change set for one composition resource (empty until it is observed).
+_changesFor = lambda ocds: any, cr: str -> [any] {
+    _fp = _get(ocds, cr + ".Resource.spec.forProvider", Undefined)
+    _ap = _get(ocds, cr + ".Resource.status.atProvider", Undefined)
+    _deepDiff(_fp, _ap, "") if (typeof(_fp) == "dict" and typeof(_ap) == "dict") else []
+}
+
+# Per-resource report entry: external name, observed flag, and the change set
+# partitioned into reconcilable drift vs unreconcilable side effects.
+_entry = lambda ocds: any, importResources: any, cr: str, key: str, reconcilable: [str] -> any {
+    _changes = _changesFor(ocds, cr)
+    {
+        externalName = importResources[key]
+        observed = _get(ocds, cr + ".Resource.status.atProvider", Undefined) != Undefined
+        drift = [c for c in _changes if _isReconcilable(c.field, reconcilable)]
+        sideEffects = [c for c in _changes if not _isReconcilable(c.field, reconcilable)]
+    }
+}
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+# Deep diff of a single resource's desired (forProvider) vs observed (atProvider).
+diff = lambda desired: any, observed: any -> [Change] {
+    """Deep forProvider-vs-atProvider diff -> list of Change."""
+    _deepDiff(desired, observed, "")
+}
+
+managementPolicies = lambda importActive: bool, commit: bool, default: [str] -> [str] {
+    """Import lifecycle -> Crossplane management policies.
+
+    observe (importing, not committed) -> ["Observe", "LateInitialize"] (read-only to the cloud);
+    commit  (importing, committed)     -> ["*"] (full management);
+    otherwise (not importing)          -> the supplied default.
+    """
+    ["Observe", "LateInitialize"] if (importActive and not commit) else (["*"] if importActive else default)
+}
+
+buildReport = lambda config: {str:} -> {str:} {
+    """Compute the import report from observed composed resources.
+
+    config:
+      ocds            observed composed resources (option("params").ocds)
+      importResources {logicalKey: externalName} from spec.parameters.import.resources
+      registry        {logicalKey: compositionResourceName} - the importable resources
+      reconcilable    [leaf field names] backed by editable parameters (-> drift)
+      requiredKeys    [logicalKey] that must all be present, else the render is blocked
+
+    returns:
+      { missing, blockRender, resources, driftCount, sideEffectCount }
+    where resources[key] = { externalName, observed, drift: [Change], sideEffects: [Change] }.
+    The composition wraps this into status.import (adding active/commit/phase) and
+    uses blockRender to decide whether to emit managed resources.
+    """
+    _ocds = config.ocds
+    _import = config.importResources
+    _registry = config.registry
+    _recon = config.reconcilable
+    _required = config.requiredKeys
+
+    _missing = [k for k in _required if k not in _import]
+    _block = len(_missing) > 0
+    _reportKeys = [k for k in _registry if k in _import]
+    _resources = {k: _entry(_ocds, _import, _registry[k], k, _recon) for k in _reportKeys} if not _block else {}
+    _driftLens = [len(_resources[k].drift) for k in _resources]
+    _sideLens = [len(_resources[k].sideEffects) for k in _resources]
+    {
+        missing = _missing
+        blockRender = _block
+        resources = _resources
+        driftCount = sum(_driftLens) if len(_driftLens) > 0 else 0
+        sideEffectCount = sum(_sideLens) if len(_sideLens) > 0 else 0
+    }
+}

--- a/functions/eks/main.k
+++ b/functions/eks/main.k
@@ -13,12 +13,32 @@ dcds = option("params").dcds # desired composed resources
 
 params = oxr.spec.parameters
 
+_import = params["import"] if "import" in params else {}
+_importResources = _import["resources"] if "resources" in _import else {}
+_importActive = len(_importResources) > 0
+_commit = _import["commit"] if "commit" in _import else False
+
+# Existing/remote network placement. When subnetIds is provided the cluster and node
+# group use these subnets directly (existing VPC / brownfield); otherwise the composition
+# selects subnets from a Network it composes (greenfield default).
+_network = params["network"] if "network" in params else {}
+_explicitSubnets = _network["subnetIds"] if "subnetIds" in _network else []
+_explicitNodeSubnets = _network["nodeSubnetIds"] if "nodeSubnetIds" in _network else _explicitSubnets
+_useExplicitNetwork = len(_explicitSubnets) > 0
+
 xrName = oxr.metadata.name
 
 _metadata = lambda name: str -> any {
     {
         annotations = {"krm.kcl.dev/composition-resource-name" = name}
     }
+}
+
+_extAnno = lambda key: str -> {str:str} {
+    {"crossplane.io/external-name" = _importResources[key]} if (_importActive and key in _importResources) else {}
+}
+_metaImp = lambda name: str, key: str -> any {
+    { annotations = {"krm.kcl.dev/composition-resource-name" = name} | _extAnno(key) }
 }
 
 ready = lambda o: any, statusPath = "atProvider" -> bool {
@@ -43,8 +63,11 @@ get = lambda x: any, y: str, d: any -> any {
     x[c] if len(p) == 1 and c in x else d if c not in x else get(x[c], y, d)
 }
 
+_mgmtPolicies = ["Observe", "LateInitialize"] if (_importActive and not _commit) else \
+    (["*"] if _importActive else (params.managementPolicies or ["*"]))
+
 _defaults = {
-    managementPolicies = params.managementPolicies or ["*"]
+    managementPolicies = _mgmtPolicies
     if params.providerConfigName:
         providerConfigRef = {
             kind = "ProviderConfig"
@@ -56,7 +79,7 @@ _items = []
 
 _items += [
     iamv1beta1.Role {
-        metadata = _metadata("controlplaneRole") | {
+        metadata = _metaImp("controlplaneRole", "controlplaneRole") | {
             labels: {
                 role = "controlplane"
             }
@@ -88,7 +111,7 @@ _items += [
         }
     }
     eksv1beta1.Cluster {
-        metadata = _metadata("kubernetesCluster")
+        metadata = _metaImp("kubernetesCluster", "kubernetesCluster")
         spec: _defaults | {
             forProvider = {
                 region = params.region
@@ -105,10 +128,16 @@ _items += [
                 }
                 vpcConfig = {
                     endpointPrivateAccess = True
-                    subnetIdSelector.matchLabels = {
-                        "networks.aws.platform.upbound.io/network-id" = params.id
-                        access = "public"
-                    }
+                    # Explicit subnets (existing VPC / brownfield) take precedence. Otherwise
+                    # select subnets from the composed Network by label (greenfield). We never
+                    # use the selector in import mode because brownfield subnets are unlabelled.
+                    if _useExplicitNetwork:
+                        subnetIds = _explicitSubnets
+                    if (not _useExplicitNetwork) and (not _importActive):
+                        subnetIdSelector.matchLabels = {
+                            "networks.aws.platform.upbound.io/network-id" = params.id
+                            access = "public"
+                        }
                 }
             }
         }
@@ -136,11 +165,14 @@ if clusterSecurityGroupId:
         }
     ]
 
-if ready(get(_ocds, "kubernetesCluster", "")) or exists("kubernetesClusterAuth"):
+if _importActive or ready(get(_ocds, "kubernetesCluster", "")) or exists("kubernetesClusterAuth"):
     _items += [
         eksv1beta1.ClusterAuth {
             metadata = _metadata("kubernetesClusterAuth")
             spec: _defaults | {
+                # ClusterAuth is a token generator with no importable external state and does
+                # not support observe-only management policies, so it always runs normally.
+                managementPolicies = params.managementPolicies or ["*"]
                 forProvider = {
                     region = params.region
                     clusterNameSelector.matchControllerRef = True
@@ -154,7 +186,7 @@ if ready(get(_ocds, "kubernetesCluster", "")) or exists("kubernetesClusterAuth")
 
 _items += [
     iamv1beta1.Role {
-        metadata = _metadata("nodegroupRole") | {
+        metadata = _metaImp("nodegroupRole", "nodegroupRole") | {
             labels = {
                 role = "nodegroup"
             }
@@ -193,10 +225,10 @@ _items += [
 nodeCount = oxr.spec.parameters.nodes.count or ""
 instanceType = oxr.spec.parameters.nodes.instanceType or ""
 
-if ready(get(_ocds, "vpc-cni-addon", "")) or exists("nodeGroupPublic"):
+if _importActive or ready(get(_ocds, "vpc-cni-addon", "")) or exists("nodeGroupPublic"):
     _items += [
         eksv1beta1.NodeGroup {
-            metadata = _metadata("nodeGroupPublic")
+            metadata = _metaImp("nodeGroupPublic", "nodeGroupPublic")
             spec: _defaults | {
                 initProvider = {
                     scalingConfig = {
@@ -217,10 +249,15 @@ if ready(get(_ocds, "vpc-cni-addon", "")) or exists("nodeGroupPublic"):
                         minSize = 1
                     }
                     instanceTypes = [instanceType]
-                    subnetIdSelector.matchLabels = {
-                        "networks.aws.platform.upbound.io/network-id" = params.id
-                        access = "public"
-                    }
+                    # Explicit node subnets (existing VPC / brownfield) take precedence; node group
+                    # subnets are immutable so for import they must match the existing node group.
+                    if _useExplicitNetwork:
+                        subnetIds = _explicitNodeSubnets
+                    if (not _useExplicitNetwork) and (not _importActive):
+                        subnetIdSelector.matchLabels = {
+                            "networks.aws.platform.upbound.io/network-id" = params.id
+                            access = "public"
+                        }
                 }
             }
         }
@@ -232,7 +269,7 @@ if principalArn:
     _items += [
         eksv1beta1.AccessEntry {
             # force recreate when principalArn changes
-            metadata = _metadata(crypto.sha256("accessEntry-{}".format(principalArn)))
+            metadata = _metaImp(crypto.sha256("accessEntry-{}".format(principalArn)), "accessEntry")
             spec: _defaults | {
                 forProvider = {
                     region = params.region
@@ -246,7 +283,7 @@ if principalArn:
         }
         eksv1beta1.AccessPolicyAssociation {
             # force recreate when principalArn changes
-            metadata = _metadata(crypto.sha256("accessPolicyAssociation-{}".format(principalArn)))
+            metadata = _metaImp(crypto.sha256("accessPolicyAssociation-{}".format(principalArn)), "accessPolicyAssociation")
             spec: _defaults | {
                 forProvider = {
                     region = params.region
@@ -265,10 +302,10 @@ if principalArn:
         }
     ]
 
-if ready(get(_ocds, "kubernetesClusterAuth", {})) or exists("vpc-cni-addon"):
+if _importActive or ready(get(_ocds, "kubernetesClusterAuth", {})) or exists("vpc-cni-addon"):
     _items += [
         eksv1beta1.Addon {
-            metadata = _metadata("vpc-cni-addon")
+            metadata = _metaImp("vpc-cni-addon", "vpcCniAddon")
             spec: _defaults | {
                 forProvider = {
                     region = params.region
@@ -283,7 +320,7 @@ if ready(get(_ocds, "kubernetesClusterAuth", {})) or exists("vpc-cni-addon"):
 
 _items += [
     iamv1beta1.Role {
-        metadata = _metadata("ebsCSIDriverRole") | {
+        metadata = _metaImp("ebsCSIDriverRole", "ebsCSIDriverRole") | {
             labels = {
                 role = "ebs-csi-driver"
             }
@@ -317,7 +354,7 @@ _items += [
 
 _items += [
     eksv1beta1.PodIdentityAssociation {
-        metadata = _metadata("ebsCSIDriverPodIdentityAssociation")
+        metadata = _metaImp("ebsCSIDriverPodIdentityAssociation", "ebsCSIDriverPodIdentityAssociation")
         spec: _defaults | {
             forProvider = {
                 region = params.region
@@ -335,10 +372,10 @@ _items += [
     }
 ]
 
-if (ready(get(_ocds, "ebsCSIDriverPodIdentityAssociation", "")) and ready(get(_ocds, "nodeGroupPublic", ""))) or exists("aws-ebs-csi-driver-addon"):
+if _importActive or (ready(get(_ocds, "ebsCSIDriverPodIdentityAssociation", "")) and ready(get(_ocds, "nodeGroupPublic", ""))) or exists("aws-ebs-csi-driver-addon"):
     _items += [
         eksv1beta1.Addon {
-            metadata = _metadata("aws-ebs-csi-driver-addon")
+            metadata = _metaImp("aws-ebs-csi-driver-addon", "ebsCsiAddon")
             spec: _defaults | {
                 forProvider = {
                     region = params.region
@@ -350,10 +387,10 @@ if (ready(get(_ocds, "ebsCSIDriverPodIdentityAssociation", "")) and ready(get(_o
         }
     ]
 
-if ready(get(_ocds, "nodeGroupPublic", "")) or exists("eks-pod-identity-agent"):
+if _importActive or ready(get(_ocds, "nodeGroupPublic", "")) or exists("eks-pod-identity-agent"):
     _items += [
         eksv1beta1.Addon {
-            metadata = _metadata("eks-pod-identity-agent-addon")
+            metadata = _metaImp("eks-pod-identity-agent-addon", "podIdentityAgentAddon")
             spec: _defaults | {
                 forProvider = {
                     region = params.region
@@ -417,6 +454,12 @@ _items += [{
         data: {}
 }]
 
+# Validation and drift detection for import mode
+_requiredKeys = ["controlplaneRole","nodegroupRole","ebsCSIDriverRole","kubernetesCluster","nodeGroupPublic","vpcCniAddon","ebsCsiAddon","podIdentityAgentAddon","ebsCSIDriverPodIdentityAssociation"]
+_requiredKeys += (["accessEntry","accessPolicyAssociation"] if principalArn else [])
+_missing = [k for k in _requiredKeys if k not in _importResources] if _importActive else []
+_blockRender = _importActive and len(_missing) > 0
+
 # Read the observed Cluster / NodeGroup atProvider blocks (None until they
 # sync). Surfacing these on the EKS status lets higher-level configurations
 # (e.g. configuration-aws-ctp) read the OIDC issuer, cluster ARN and running
@@ -431,6 +474,120 @@ _oidcIssuerUrl = (_oidcList[0]?.issuer or "") if len(_oidcList) > 0 else ""
 
 _ngInstanceTypes = _ngAtProvider?.instanceTypes or []
 
+# --- Generic import diff ----------------------------------------------------
+# spec.forProvider is the source of truth; status.atProvider is live cloud state.
+# Committing (managementPolicies -> ["*"]) converges live to desired, so the full
+# set of changes a commit would make is a deep diff of forProvider vs atProvider,
+# read straight off each observed managed resource. There is no per-field
+# curation: any leaf the composition declares that the cloud disagrees with shows
+# up automatically. Desired values are read from the OBSERVED resource's
+# forProvider, which already carries the provider-injected defaults (e.g. the
+# crossplane-* tags) and LateInitialized fields, so it reflects exactly what the
+# provider would enforce on commit.
+#
+# Each change is classified using the only hardcoded knowledge left - a short
+# list of leaf names that trace back to an editable XR parameter:
+#   drift        - reconcilable by editing spec.parameters before commit; summed
+#                  into driftCount ("drive this to what you intend, then commit").
+#   sideEffects  - everything else a commit would do with no param knob (tag
+#                  rewrites, composition/provider-fixed fields, immutable fields
+#                  the provider will refuse to replace); summed into sideEffectCount.
+
+# Composition-resource-name for each importable logical key (+ access* when an
+# IAM principal is configured).
+_importCR = {
+    kubernetesCluster = "kubernetesCluster"
+    nodeGroupPublic = "nodeGroupPublic"
+    controlplaneRole = "controlplaneRole"
+    nodegroupRole = "nodegroupRole"
+    ebsCSIDriverRole = "ebsCSIDriverRole"
+    vpcCniAddon = "vpc-cni-addon"
+    ebsCsiAddon = "aws-ebs-csi-driver-addon"
+    podIdentityAgentAddon = "eks-pod-identity-agent-addon"
+    ebsCSIDriverPodIdentityAssociation = "ebsCSIDriverPodIdentityAssociation"
+} | ({
+    accessEntry = crypto.sha256("accessEntry-{}".format(principalArn))
+    accessPolicyAssociation = crypto.sha256("accessPolicyAssociation-{}".format(principalArn))
+} if principalArn else {})
+
+# Leaf field names backed by an editable XR parameter (reconcilable drift).
+# Everything else that differs is an unreconcilable side effect of committing.
+_reconcilable = ["version", "authenticationMode", "instanceTypes", "desiredSize", "subnetIds"]
+
+# Crossplane cross-resource wiring / provider-computed mirrors: never real cloud
+# state, so skipping them avoids false positives.
+_skipKey = lambda k: str -> bool {
+    k.endswith("Ref") or k.endswith("Refs") or k.endswith("Selector") or k == "tagsAll"
+}
+
+# Bidirectional diff for open-keyed maps (tags): removals (live but not desired ->
+# committing strips them) and additions/updates (desired but not live / changed).
+# An omitted `desired` means "would be removed"; an omitted `observed` means
+# "would be added".
+_mapDiff = lambda fp: any, ap: any, path: str -> [any] {
+    _rm = [{field = "{}[{}]".format(path, k), observed = ap[k]} for k in ap if k not in fp]
+    _ch = [{field = "{}[{}]".format(path, k), desired = fp[k], observed = (ap[k] if k in ap else Undefined)} for k in fp if (k not in ap or ap[k] != fp[k])]
+    _rm + _ch
+}
+
+# Scalar (order-insensitive) list handling: AWS set-like fields (subnetIds,
+# managedPolicyArns, ...) come back from the cloud in a different order than the
+# composition declares them, which is not a real change. Compare such lists as
+# sets so ordering alone never registers as drift.
+_isScalar = lambda v: any -> bool {
+    typeof(v) in ["str", "int", "float", "bool"]
+}
+_scalarList = lambda v: any -> bool {
+    typeof(v) == "list" and (all e in v { _isScalar(e) })
+}
+_sameSet = lambda a: any, b: any -> bool {
+    len(a) == len(b) and (all e in a { e in b }) and (all e in b { e in a })
+}
+
+# Deep diff driven by desired (forProvider). Recurses into nested objects, but
+# only descends when the observed side is also an object - an absent observed
+# subtree means the cloud does not report it, which is not a committable change.
+_diffField = lambda k: str, dv: any, ov: any, path: str -> [any] {
+    _valueChanged = (not _sameSet(dv, ov)) if (_scalarList(dv) and _scalarList(ov)) else (dv != ov)
+    _leafChanged = ov != Undefined and ov != None and _valueChanged
+    _leaf = [{field = path, desired = dv, observed = ov}] if _leafChanged else []
+    _obj = _deepDiff(dv, ov, path) if (typeof(dv) == "dict" and typeof(ov) == "dict") else _leaf
+    _mapDiff(dv or {}, ov or {}, path) if k == "tags" else _obj
+}
+_deepDiff = lambda desired: any, observed: any, prefix: str -> [any] {
+    sum([
+        _diffField(k, desired[k], (observed[k] if (typeof(observed) == "dict" and k in observed) else Undefined), (prefix + "." + k if prefix != "" else k))
+        for k in desired if not _skipKey(k)
+    ], [])
+}
+
+# Full change set for one composition resource (empty until it is observed).
+_diffFor = lambda cr: str -> [any] {
+    _fp = get(_ocds, cr + ".Resource.spec.forProvider", Undefined)
+    _ap = get(_ocds, cr + ".Resource.status.atProvider", Undefined)
+    _deepDiff(_fp, _ap, "") if (typeof(_fp) == "dict" and typeof(_ap) == "dict") else []
+}
+_isReconcilable = lambda field: str -> bool {
+    any p in _reconcilable { field.endswith(p) }
+}
+_resourceEntry = lambda key: str -> any {
+    _cr = _importCR[key]
+    _changes = _diffFor(_cr)
+    {
+        externalName = _importResources[key]
+        observed = (get(_ocds, _cr + ".Resource.status.atProvider", Undefined) != Undefined)
+        drift = [c for c in _changes if _isReconcilable(c.field)]
+        sideEffects = [c for c in _changes if not _isReconcilable(c.field)]
+    }
+}
+
+_reportKeys = [k for k in _importCR if k in _importResources]
+_resources = {k: _resourceEntry(k) for k in _reportKeys} if (_importActive and not _blockRender) else {}
+_driftLens = [len(_resources[k].drift) for k in _resources]
+_driftCount = sum(_driftLens) if len(_driftLens) > 0 else 0
+_sideEffectLens = [len(_resources[k].sideEffects) for k in _resources]
+_sideEffectCount = sum(_sideEffectLens) if len(_sideEffectLens) > 0 else 0
+
 # Update the dxr status.
 _dxr = _dxr | {
     status: {
@@ -443,9 +600,20 @@ _dxr = _dxr | {
                 instanceType: _ngInstanceTypes[0] if len(_ngInstanceTypes) > 0 else ""
             }
         }
-    }
+    } | ({
+        "import" = {
+            active = True
+            commit = _commit
+            phase = ("Committing" if _commit else "Observing")
+            missing = _missing
+        } | ({"error" = "import.resources is set but required external names are missing; render blocked until all are provided"} if _blockRender else {
+            resources = _resources
+            driftCount = _driftCount
+            sideEffectCount = _sideEffectCount
+        })
+    } if _importActive else {})
 }
 
 _items += [_dxr]
 
-items = _items
+items = [_dxr] if _blockRender else _items

--- a/functions/eks/main.k
+++ b/functions/eks/main.k
@@ -5,7 +5,7 @@ import models.io.crossplane.kubernetesm.v1alpha1 as k8sv1alpha1
 import models.io.crossplane.helmm.v1beta1 as helmv1beta1
 import regex
 import crypto
-import json
+import importkit
 
 oxr = option("params").oxr # observed composite resource
 _ocds = option("params").ocds # observed composed resources
@@ -64,8 +64,7 @@ get = lambda x: any, y: str, d: any -> any {
     x[c] if len(p) == 1 and c in x else d if c not in x else get(x[c], y, d)
 }
 
-_mgmtPolicies = ["Observe", "LateInitialize"] if (_importActive and not _commit) else \
-    (["*"] if _importActive else (params.managementPolicies or ["*"]))
+_mgmtPolicies = importkit.managementPolicies(_importActive, _commit, params.managementPolicies or ["*"])
 
 _defaults = {
     managementPolicies = _mgmtPolicies
@@ -455,11 +454,9 @@ _items += [{
         data: {}
 }]
 
-# Validation and drift detection for import mode
+# Import spec (EKS-specific) fed to the generic importkit engine below.
 _requiredKeys = ["controlplaneRole","nodegroupRole","ebsCSIDriverRole","kubernetesCluster","nodeGroupPublic","vpcCniAddon","ebsCsiAddon","podIdentityAgentAddon","ebsCSIDriverPodIdentityAssociation"]
 _requiredKeys += (["accessEntry","accessPolicyAssociation"] if principalArn else [])
-_missing = [k for k in _requiredKeys if k not in _importResources] if _importActive else []
-_blockRender = _importActive and len(_missing) > 0
 
 # Read the observed Cluster / NodeGroup atProvider blocks (None until they
 # sync). Surfacing these on the EKS status lets higher-level configurations
@@ -475,28 +472,15 @@ _oidcIssuerUrl = (_oidcList[0]?.issuer or "") if len(_oidcList) > 0 else ""
 
 _ngInstanceTypes = _ngAtProvider?.instanceTypes or []
 
-# --- Generic import diff ----------------------------------------------------
-# spec.forProvider is the source of truth; status.atProvider is live cloud state.
-# Committing (managementPolicies -> ["*"]) converges live to desired, so the full
-# set of changes a commit would make is a deep diff of forProvider vs atProvider,
-# read straight off each observed managed resource. There is no per-field
-# curation: any leaf the composition declares that the cloud disagrees with shows
-# up automatically. Desired values are read from the OBSERVED resource's
-# forProvider, which already carries the provider-injected defaults (e.g. the
-# crossplane-* tags) and LateInitialized fields, so it reflects exactly what the
-# provider would enforce on commit.
-#
-# Each change is classified using the only hardcoded knowledge left - a short
-# list of leaf names that trace back to an editable XR parameter:
-#   drift        - reconcilable by editing spec.parameters before commit; summed
-#                  into driftCount ("drive this to what you intend, then commit").
-#   sideEffects  - everything else a commit would do with no param knob (tag
-#                  rewrites, composition/provider-fixed fields, immutable fields
-#                  the provider will refuse to replace); summed into sideEffectCount.
-
-# Composition-resource-name for each importable logical key (+ access* when an
-# IAM principal is configured).
-_importCR = {
+# --- Generic import diff (delegated to the importkit module) ----------------
+# The whole diff/classify/report engine lives in importkit.k (provider-agnostic,
+# reusable). This composition only supplies the EKS-specific spec:
+#   registry     - importable logical key -> composition-resource-name (+ access*
+#                  when an IAM principal is configured).
+#   reconcilable - leaf field names backed by an editable XR parameter; matching
+#                  changes are reconcilable `drift`, everything else is a
+#                  `sideEffect` that committing applies with no param knob.
+_registry = {
     kubernetesCluster = "kubernetesCluster"
     nodeGroupPublic = "nodeGroupPublic"
     controlplaneRole = "controlplaneRole"
@@ -511,103 +495,15 @@ _importCR = {
     accessPolicyAssociation = crypto.sha256("accessPolicyAssociation-{}".format(principalArn))
 } if principalArn else {})
 
-# Leaf field names backed by an editable XR parameter (reconcilable drift).
-# Everything else that differs is an unreconcilable side effect of committing.
 _reconcilable = ["version", "authenticationMode", "instanceTypes", "desiredSize", "subnetIds"]
 
-# Crossplane cross-resource wiring / provider-computed mirrors: never real cloud
-# state, so skipping them avoids false positives.
-_skipKey = lambda k: str -> bool {
-    k.endswith("Ref") or k.endswith("Refs") or k.endswith("Selector") or k == "tagsAll"
-}
-
-# Bidirectional diff for open-keyed maps (tags): removals (live but not desired ->
-# committing strips them) and additions/updates (desired but not live / changed).
-# An omitted `desired` means "would be removed"; an omitted `observed` means
-# "would be added".
-_mapDiff = lambda fp: any, ap: any, path: str -> [any] {
-    _rm = [{field = "{}[{}]".format(path, k), observed = ap[k]} for k in ap if k not in fp]
-    _ch = [{field = "{}[{}]".format(path, k), desired = fp[k], observed = (ap[k] if k in ap else Undefined)} for k in fp if (k not in ap or ap[k] != fp[k])]
-    _rm + _ch
-}
-
-# Scalar (order-insensitive) list handling: AWS set-like fields (subnetIds,
-# managedPolicyArns, ...) come back from the cloud in a different order than the
-# composition declares them, which is not a real change. Compare such lists as
-# sets so ordering alone never registers as drift.
-_isScalar = lambda v: any -> bool {
-    typeof(v) in ["str", "int", "float", "bool"]
-}
-_scalarList = lambda v: any -> bool {
-    typeof(v) == "list" and (all e in v { _isScalar(e) })
-}
-_sameSet = lambda a: any, b: any -> bool {
-    len(a) == len(b) and (all e in a { e in b }) and (all e in b { e in a })
-}
-
-# JSON-string handling: many AWS fields (IAM assumeRolePolicy, addon
-# configurationValues, ...) are JSON serialized into a string. The composition
-# declares them pretty-printed / in one key order while the cloud returns them
-# compacted / reordered, so a raw string compare reports formatting-only diffs.
-# Detection is structural (no field-name list): a string is treated as JSON only
-# if it opens like a JSON object - `{"...` or `{}` - which also rejects lookalikes
-# such as Go templates (`{{ ... }}`). `[`-strings are intentionally NOT treated as
-# JSON (e.g. `[INFO] ...` is not an array) to keep json.decode from ever seeing
-# non-JSON (KCL has no way to recover from a decode error).
-_looksJson = lambda s: str -> bool {
-    regex.match(s, "^\\s*\\{\\s*(\"|\\})")
-}
-# Semantic equality via decode; KCL dict equality is key-order independent, so
-# this collapses whitespace and key-order differences.
-_jsonEqual = lambda a: str, b: str -> bool {
-    json.decode(a) == json.decode(b)
-}
-
-# Deep diff driven by desired (forProvider). Recurses into nested objects, but
-# only descends when the observed side is also an object - an absent observed
-# subtree means the cloud does not report it, which is not a committable change.
-_diffField = lambda k: str, dv: any, ov: any, path: str -> [any] {
-    _jsonPair = typeof(dv) == "str" and typeof(ov) == "str" and _looksJson(dv) and _looksJson(ov)
-    _listPair = _scalarList(dv) and _scalarList(ov)
-    _valueChanged = (not _jsonEqual(dv, ov)) if _jsonPair else ((not _sameSet(dv, ov)) if _listPair else (dv != ov))
-    _leafChanged = ov != Undefined and ov != None and _valueChanged
-    _leaf = [{field = path, desired = dv, observed = ov}] if _leafChanged else []
-    _obj = _deepDiff(dv, ov, path) if (typeof(dv) == "dict" and typeof(ov) == "dict") else _leaf
-    _mapDiff(dv or {}, ov or {}, path) if k == "tags" else _obj
-}
-_deepDiff = lambda desired: any, observed: any, prefix: str -> [any] {
-    sum([
-        _diffField(k, desired[k], (observed[k] if (typeof(observed) == "dict" and k in observed) else Undefined), (prefix + "." + k if prefix != "" else k))
-        for k in desired if not _skipKey(k)
-    ], [])
-}
-
-# Full change set for one composition resource (empty until it is observed).
-_diffFor = lambda cr: str -> [any] {
-    _fp = get(_ocds, cr + ".Resource.spec.forProvider", Undefined)
-    _ap = get(_ocds, cr + ".Resource.status.atProvider", Undefined)
-    _deepDiff(_fp, _ap, "") if (typeof(_fp) == "dict" and typeof(_ap) == "dict") else []
-}
-_isReconcilable = lambda field: str -> bool {
-    any p in _reconcilable { field.endswith(p) }
-}
-_resourceEntry = lambda key: str -> any {
-    _cr = _importCR[key]
-    _changes = _diffFor(_cr)
-    {
-        externalName = _importResources[key]
-        observed = (get(_ocds, _cr + ".Resource.status.atProvider", Undefined) != Undefined)
-        drift = [c for c in _changes if _isReconcilable(c.field)]
-        sideEffects = [c for c in _changes if not _isReconcilable(c.field)]
-    }
-}
-
-_reportKeys = [k for k in _importCR if k in _importResources]
-_resources = {k: _resourceEntry(k) for k in _reportKeys} if (_importActive and not _blockRender) else {}
-_driftLens = [len(_resources[k].drift) for k in _resources]
-_driftCount = sum(_driftLens) if len(_driftLens) > 0 else 0
-_sideEffectLens = [len(_resources[k].sideEffects) for k in _resources]
-_sideEffectCount = sum(_sideEffectLens) if len(_sideEffectLens) > 0 else 0
+_report = importkit.buildReport({
+    ocds = _ocds
+    importResources = _importResources
+    registry = _registry
+    reconcilable = _reconcilable
+    requiredKeys = _requiredKeys
+}) if _importActive else {missing = [], blockRender = False, resources = {}, driftCount = 0, sideEffectCount = 0}
 
 # Update the dxr status.
 _dxr = _dxr | {
@@ -626,15 +522,15 @@ _dxr = _dxr | {
             active = True
             commit = _commit
             phase = ("Committing" if _commit else "Observing")
-            missing = _missing
-        } | ({"error" = "import.resources is set but required external names are missing; render blocked until all are provided"} if _blockRender else {
-            resources = _resources
-            driftCount = _driftCount
-            sideEffectCount = _sideEffectCount
+            missing = _report.missing
+        } | ({"error" = "import.resources is set but required external names are missing; render blocked until all are provided"} if _report.blockRender else {
+            resources = _report.resources
+            driftCount = _report.driftCount
+            sideEffectCount = _report.sideEffectCount
         })
     } if _importActive else {})
 }
 
 _items += [_dxr]
 
-items = [_dxr] if _blockRender else _items
+items = [_dxr] if _report.blockRender else _items

--- a/functions/eks/main.k
+++ b/functions/eks/main.k
@@ -5,6 +5,7 @@ import models.io.crossplane.kubernetesm.v1alpha1 as k8sv1alpha1
 import models.io.crossplane.helmm.v1beta1 as helmv1beta1
 import regex
 import crypto
+import json
 
 oxr = option("params").oxr # observed composite resource
 _ocds = option("params").ocds # observed composed resources
@@ -544,11 +545,31 @@ _sameSet = lambda a: any, b: any -> bool {
     len(a) == len(b) and (all e in a { e in b }) and (all e in b { e in a })
 }
 
+# JSON-string handling: many AWS fields (IAM assumeRolePolicy, addon
+# configurationValues, ...) are JSON serialized into a string. The composition
+# declares them pretty-printed / in one key order while the cloud returns them
+# compacted / reordered, so a raw string compare reports formatting-only diffs.
+# Detection is structural (no field-name list): a string is treated as JSON only
+# if it opens like a JSON object - `{"...` or `{}` - which also rejects lookalikes
+# such as Go templates (`{{ ... }}`). `[`-strings are intentionally NOT treated as
+# JSON (e.g. `[INFO] ...` is not an array) to keep json.decode from ever seeing
+# non-JSON (KCL has no way to recover from a decode error).
+_looksJson = lambda s: str -> bool {
+    regex.match(s, "^\\s*\\{\\s*(\"|\\})")
+}
+# Semantic equality via decode; KCL dict equality is key-order independent, so
+# this collapses whitespace and key-order differences.
+_jsonEqual = lambda a: str, b: str -> bool {
+    json.decode(a) == json.decode(b)
+}
+
 # Deep diff driven by desired (forProvider). Recurses into nested objects, but
 # only descends when the observed side is also an object - an absent observed
 # subtree means the cloud does not report it, which is not a committable change.
 _diffField = lambda k: str, dv: any, ov: any, path: str -> [any] {
-    _valueChanged = (not _sameSet(dv, ov)) if (_scalarList(dv) and _scalarList(ov)) else (dv != ov)
+    _jsonPair = typeof(dv) == "str" and typeof(ov) == "str" and _looksJson(dv) and _looksJson(ov)
+    _listPair = _scalarList(dv) and _scalarList(ov)
+    _valueChanged = (not _jsonEqual(dv, ov)) if _jsonPair else ((not _sameSet(dv, ov)) if _listPair else (dv != ov))
     _leafChanged = ov != Undefined and ov != None and _valueChanged
     _leaf = [{field = path, desired = dv, observed = ov}] if _leafChanged else []
     _obj = _deepDiff(dv, ov, path) if (typeof(dv) == "dict" and typeof(ov) == "dict") else _leaf

--- a/tests/test-eks-import/kcl.mod
+++ b/tests/test-eks-import/kcl.mod
@@ -1,0 +1,6 @@
+[package]
+name = "test-eks-import"
+version = "0.0.1"
+
+[dependencies]
+models = { path = "./model" }

--- a/tests/test-eks-import/kcl.mod.lock
+++ b/tests/test-eks-import/kcl.mod.lock
@@ -1,0 +1,5 @@
+[dependencies]
+  [dependencies.models]
+    name = "models"
+    full_name = "models_0.0.1"
+    version = "0.0.1"

--- a/tests/test-eks-import/main.k
+++ b/tests/test-eks-import/main.k
@@ -70,11 +70,29 @@ _observedCluster = eksv1beta1.Cluster {
     }
 }
 
+# A JSON-string field (addon configurationValues) that is semantically identical
+# but differently whitespaced AND key-ordered. Structural json-normalization must
+# treat this as NO change, so it must not appear in drift or sideEffects. Without
+# normalization it would inflate sideEffectCount to 7.
+_observedVpcCniAddon = {
+    apiVersion = "eks.aws.m.upbound.io/v1beta1"
+    kind = "Addon"
+    metadata = {
+        annotations = {
+            "crossplane.io/composition-resource-name" = "vpc-cni-addon"
+        }
+        name = "imported-vpc-cni"
+        namespace = "default"
+    }
+    spec.forProvider.configurationValues = '{"env": {"B": "2", "AWS_VPC_K8S_CNI_CUSTOM_NETWORK_CFG": "false"}}'
+    status.atProvider.configurationValues = '{\n  "env": {\n    "AWS_VPC_K8S_CNI_CUSTOM_NETWORK_CFG": "false",\n    "B": "2"\n  }\n}'
+}
+
 _test_observe = metav1alpha1.CompositionTest {
     metadata.name = "import-observe-drift"
     spec = _common | {
         xrPath = "tests/test-eks-import/xr-observe.yaml"
-        observedResources = [_observedCluster]
+        observedResources = [_observedCluster, _observedVpcCniAddon]
         assertResources = [
             # Cluster rendered observe-only with the external name pinned.
             eksv1beta1.Cluster {

--- a/tests/test-eks-import/main.k
+++ b/tests/test-eks-import/main.k
@@ -1,0 +1,191 @@
+"""
+    Brownfield import test suite.
+
+    Validates the import lifecycle driven from spec.parameters.import:
+      - observe:  external-name pinned, managementPolicies forced to observe-only,
+                  and status.import drift report computed from observed atProvider.
+      - missing:  a non-empty import.resources that omits required keys blocks the
+                  render and reports status.import.missing + error.
+      - commit:   import.commit=true switches managementPolicies to ["*"] while the
+                  external-name stays pinned.
+
+    The composite (EKS) status assertions use plain dicts because `import` is a KCL
+    keyword and cannot be a schema attribute identifier.
+"""
+
+import models.io.upbound.awsm.eks.v1beta1 as eksv1beta1
+import models.io.upbound.dev.meta.v1alpha1 as metav1alpha1
+
+_common = {
+    compositionPath = "apis/eks/composition.yaml"
+    xrdPath = "apis/eks/definition.yaml"
+    timeoutSeconds = 60
+    validate = False
+}
+
+# --- observe phase: pin external-name, observe-only, and detect version drift ---
+# XR wants version 1.34; the live cluster reports 1.33 -> one drift entry.
+_observedCluster = eksv1beta1.Cluster {
+    metadata = {
+        annotations = {
+            "crossplane.io/composition-resource-name" = "kubernetesCluster"
+        }
+        name = "imported-eks-cluster"
+        namespace = "default"
+    }
+    spec = {
+        forProvider = {
+            region = "us-west-2"
+            # Desired version (composition renders params.version into forProvider);
+            # the live cluster is a minor behind -> reconcilable drift.
+            version = "1.34"
+            # Desired tags = the provider-injected crossplane-* defaults (the
+            # composition itself sets no tags on the cluster).
+            tags = {
+                "crossplane-kind" = "cluster.eks.aws.m.upbound.io"
+                "crossplane-name" = "imported-eks-cluster"
+                "crossplane-providerconfig" = "default"
+            }
+            vpcConfig = {
+                endpointPrivateAccess = True
+            }
+        }
+    }
+    status = {
+        atProvider = {
+            version = "1.33"
+            accessConfig = {
+                authenticationMode = "API_AND_CONFIG_MAP"
+            }
+            # Live tags come from the out-of-band tool (e.g. eksctl); committing
+            # would strip these (2 removes) and add the 3 crossplane-* tags.
+            tags = {
+                "Name" = "eksctl-imported/ControlPlane"
+                "alpha.eksctl.io/cluster-name" = "imported-eks-cluster"
+            }
+            vpcConfig = {
+                endpointPrivateAccess = False
+            }
+        }
+    }
+}
+
+_test_observe = metav1alpha1.CompositionTest {
+    metadata.name = "import-observe-drift"
+    spec = _common | {
+        xrPath = "tests/test-eks-import/xr-observe.yaml"
+        observedResources = [_observedCluster]
+        assertResources = [
+            # Cluster rendered observe-only with the external name pinned.
+            eksv1beta1.Cluster {
+                metadata = {
+                    annotations = {
+                        "crossplane.io/composition-resource-name" = "kubernetesCluster"
+                        "crossplane.io/external-name" = "imported-eks-cluster"
+                    }
+                    # render assigns the observed resource's name to the desired resource
+                    name = "imported-eks-cluster"
+                    namespace = "default"
+                }
+                spec = {
+                    managementPolicies = ["Observe", "LateInitialize"]
+                    forProvider.region = "us-west-2"
+                }
+            }
+            # Composite status.import shows the observe phase and the version drift.
+            {
+                apiVersion = "aws.platform.upbound.io/v1alpha1"
+                kind = "EKS"
+                metadata = {name = "imported-eks", namespace = "default"}
+                status = {
+                    "import" = {
+                        active = True
+                        commit = False
+                        phase = "Observing"
+                        missing = []
+                        # Generic forProvider-vs-atProvider diff: version is the
+                        # only reconcilable (param-backed) change.
+                        driftCount = 1
+                        # 2 eksctl tags removed + 3 crossplane-* tags added +
+                        # endpointPrivateAccess false->true = 6 non-reconcilable
+                        # changes committing would make beyond reconcilable drift.
+                        sideEffectCount = 6
+                        resources = {
+                            kubernetesCluster = {
+                                externalName = "imported-eks-cluster"
+                                observed = True
+                                drift = [{field = "version", desired = "1.34", observed = "1.33"}]
+                            }
+                        }
+                    }
+                }
+            }
+        ]
+    }
+}
+
+# --- missing keys: render blocked, missing list + error surfaced ---
+_test_missing = metav1alpha1.CompositionTest {
+    metadata.name = "import-missing-blocks-render"
+    spec = _common | {
+        xrPath = "tests/test-eks-import/xr-missing.yaml"
+        assertResources = [
+            {
+                apiVersion = "aws.platform.upbound.io/v1alpha1"
+                kind = "EKS"
+                metadata = {name = "imported-eks", namespace = "default"}
+                status = {
+                    "import" = {
+                        active = True
+                        commit = False
+                        phase = "Observing"
+                        missing = [
+                            "ebsCSIDriverRole"
+                            "kubernetesCluster"
+                            "nodeGroupPublic"
+                            "vpcCniAddon"
+                            "ebsCsiAddon"
+                            "podIdentityAgentAddon"
+                            "ebsCSIDriverPodIdentityAssociation"
+                        ]
+                        error = "import.resources is set but required external names are missing; render blocked until all are provided"
+                    }
+                }
+            }
+        ]
+    }
+}
+
+# --- commit phase: full management, external-name still pinned ---
+_test_commit = metav1alpha1.CompositionTest {
+    metadata.name = "import-commit-takes-management"
+    spec = _common | {
+        xrPath = "tests/test-eks-import/xr-commit.yaml"
+        assertResources = [
+            eksv1beta1.Cluster {
+                metadata.annotations = {
+                    "crossplane.io/composition-resource-name" = "kubernetesCluster"
+                    "crossplane.io/external-name" = "imported-eks-cluster"
+                }
+                spec = {
+                    managementPolicies = ["*"]
+                    forProvider.region = "us-west-2"
+                }
+            }
+            {
+                apiVersion = "aws.platform.upbound.io/v1alpha1"
+                kind = "EKS"
+                metadata = {name = "imported-eks", namespace = "default"}
+                status = {
+                    "import" = {
+                        active = True
+                        commit = True
+                        phase = "Committing"
+                    }
+                }
+            }
+        ]
+    }
+}
+
+items = [_test_observe, _test_missing, _test_commit]

--- a/tests/test-eks-import/model
+++ b/tests/test-eks-import/model
@@ -1,0 +1,1 @@
+../../.up/kcl/models

--- a/tests/test-eks-import/xr-commit.yaml
+++ b/tests/test-eks-import/xr-commit.yaml
@@ -1,0 +1,28 @@
+apiVersion: aws.platform.upbound.io/v1alpha1
+kind: EKS
+metadata:
+  name: imported-eks
+  namespace: default
+spec:
+  parameters:
+    id: imported-eks
+    region: us-west-2
+    accessConfig:
+      authenticationMode: API_AND_CONFIG_MAP
+      bootstrapClusterCreatorAdminPermissions: true
+    version: "1.34"
+    nodes:
+      count: 1
+      instanceType: t3.small
+    import:
+      commit: true
+      resources:
+        kubernetesCluster: imported-eks-cluster
+        controlplaneRole: imported-eks-controlplane-role
+        nodegroupRole: imported-eks-nodegroup-role
+        ebsCSIDriverRole: imported-eks-ebs-csi-role
+        nodeGroupPublic: imported-ng
+        vpcCniAddon: imported-eks-cluster:vpc-cni
+        ebsCsiAddon: imported-eks-cluster:aws-ebs-csi-driver
+        podIdentityAgentAddon: imported-eks-cluster:eks-pod-identity-agent
+        ebsCSIDriverPodIdentityAssociation: a-abc1234567890abc

--- a/tests/test-eks-import/xr-missing.yaml
+++ b/tests/test-eks-import/xr-missing.yaml
@@ -1,0 +1,21 @@
+apiVersion: aws.platform.upbound.io/v1alpha1
+kind: EKS
+metadata:
+  name: imported-eks
+  namespace: default
+spec:
+  parameters:
+    id: imported-eks
+    region: us-west-2
+    accessConfig:
+      authenticationMode: API_AND_CONFIG_MAP
+      bootstrapClusterCreatorAdminPermissions: true
+    version: "1.34"
+    nodes:
+      count: 1
+      instanceType: t3.small
+    import:
+      commit: false
+      resources:
+        controlplaneRole: imported-eks-controlplane-role
+        nodegroupRole: imported-eks-nodegroup-role

--- a/tests/test-eks-import/xr-observe.yaml
+++ b/tests/test-eks-import/xr-observe.yaml
@@ -1,0 +1,28 @@
+apiVersion: aws.platform.upbound.io/v1alpha1
+kind: EKS
+metadata:
+  name: imported-eks
+  namespace: default
+spec:
+  parameters:
+    id: imported-eks
+    region: us-west-2
+    accessConfig:
+      authenticationMode: API_AND_CONFIG_MAP
+      bootstrapClusterCreatorAdminPermissions: true
+    version: "1.34"
+    nodes:
+      count: 1
+      instanceType: t3.small
+    import:
+      commit: false
+      resources:
+        kubernetesCluster: imported-eks-cluster
+        controlplaneRole: imported-eks-controlplane-role
+        nodegroupRole: imported-eks-nodegroup-role
+        ebsCSIDriverRole: imported-eks-ebs-csi-role
+        nodeGroupPublic: imported-ng
+        vpcCniAddon: imported-eks-cluster:vpc-cni
+        ebsCsiAddon: imported-eks-cluster:aws-ebs-csi-driver
+        podIdentityAgentAddon: imported-eks-cluster:eks-pod-identity-agent
+        ebsCSIDriverPodIdentityAssociation: a-abc1234567890abc

--- a/tests/test-eks-sequence/main.k
+++ b/tests/test-eks-sequence/main.k
@@ -66,10 +66,6 @@ _test2 = metav1alpha1.CompositionTest {
     spec.observedResources: [
         eksv1beta1.Cluster {
             **resources._kubernetesCluster
-            metadata: {
-                name = "configuration-aws-eks-cluster"
-                namespace = "default"
-            }
             status: {
                 atProvider:{
                     id: "test-kubernetes-cluster"
@@ -89,10 +85,6 @@ _test3 = metav1alpha1.CompositionTest {
     spec.observedResources: _test2.spec.observedResources + [
         eksv1beta1.ClusterAuth {
             **resources._kubernetesClusterAuth
-            metadata: {
-                name = "configuration-aws-eks-clusterauth"
-                namespace = "default"
-            }
             status: {
                 atProvider: {
                     lastRefreshTime: "12345"
@@ -112,10 +104,6 @@ _test4 = metav1alpha1.CompositionTest {
     spec.observedResources: _test3.spec.observedResources + [
         eksv1beta1.Addon {
             **resources._vpcCniAddon
-            metadata: {
-                name = "configuration-aws-eks-vpccni"
-                namespace = "default"
-            }
             status: {
                 atProvider:{
                     id: "test-vpc-cni-addon"
@@ -135,10 +123,6 @@ _test5 = metav1alpha1.CompositionTest {
     spec.observedResources: _test4.spec.observedResources + [
         iamv1beta1.Role {
             **resources._ebsCSIDriverRole
-            metadata: {
-                name = "configuration-aws-eks-ebscsidriverrole"
-                namespace = "default"
-            }
             status: {
                 atProvider:{
                     arn: "arn:aws:iam::123456789012:role/test-ebs-csi-driver-role"
@@ -148,10 +132,6 @@ _test5 = metav1alpha1.CompositionTest {
         }
         eksv1beta1.PodIdentityAssociation {
             **resources._ebsCSIDriverPodIdentityAssociation
-            metadata: {
-                name = "configuration-aws-eks-ebscsipodidentity"
-                namespace = "default"
-            }
             status: {
                 atProvider:{
                     associationId: "test-pod-identity-association"
@@ -161,10 +141,6 @@ _test5 = metav1alpha1.CompositionTest {
         }
         eksv1beta1.NodeGroup {
             **resources._nodeGroupPublic
-            metadata: {
-                name = "configuration-aws-eks-nodegrouppublic"
-                namespace = "default"
-            }
             status: {
                 atProvider:{
                     id: "test-nodegroup-public"


### PR DESCRIPTION
## Summary

Adds a safe, reversible **brownfield import lifecycle** so EKS clusters created out-of-band (console, Terraform, `eksctl`, …) can be adopted by this composition **without recreating or mutating them**, driven from a new `spec.parameters.import` block on the `EKS` XR.

## Lifecycle

1. **Observe** — set `import.resources` to a map of composition key → `crossplane.io/external-name` of the existing AWS resource, with `import.commit: false`. Every managed resource renders observe-only (`["Observe","LateInitialize"]`) and pinned to that name, so nothing in AWS is changed.
2. **Reconcile** — adjust `spec.parameters` until `status.import.driftCount` covers only intended changes, then review `status.import.sideEffects` (what committing will also do).
3. **Commit** — `import.commit: true` switches management to `["*"]`; the provider's refuse-to-replace guardrail protects immutable/create-time fields.
4. **Finalize** — drop the `import` block; external names persist, so the cluster stays adopted under normal management.

If `import.resources` is non-empty but any importable resource is missing its external name, the render is **blocked** (no managed resources emitted) and `status.import.missing` lists the gaps — a guardrail against a half-adopted state.

`spec.parameters.network` (`subnetIds` / `nodeSubnetIds`) lets the cluster and node group be placed in an existing VPC the composition did not create — required for import, and useful for greenfield-in-existing-VPC too.

## The report: a generic diff, not a curated field list

`status.import` is a deep diff of each resource's `spec.forProvider` (the composition's desired state — the source of truth) against its live `status.atProvider`, read straight off the observed managed resources. There is **no per-field curation**, so nothing consequential stays hidden. Each change is classified:

- **`drift`** (`driftCount`) — reconcilable by editing `spec.parameters` before commit (leaf names backed by a parameter).
- **`sideEffects`** (`sideEffectCount`) — everything else a commit would do with no parameter knob (tag rewrites, IAM policies/trust, addon config, `endpointPrivateAccess`, …).

Two normalizations keep the diff honest, both detected by shape (never by field name):

- **Order-insensitive scalar lists** — set-like fields (`subnetIds`, `managedPolicyArns`) returned in a different order than declared are compared as sets.
- **Semantic JSON** — JSON-string fields (`assumeRolePolicy`, addon `configurationValues`) are decoded and compared as data, so whitespace/key-order differences don't register. A string is treated as JSON only if it opens like a JSON object, so the parser never sees non-JSON.

## Architecture

The diff/classify/report engine is provider-agnostic — it operates on `forProvider`/`atProvider` dicts with no provider-schema dependency — and lives in a sibling KCL module, `functions/eks/importkit.k` (`deepDiff`, list/JSON normalization, `buildReport`, `managementPolicies`). The EKS function supplies only its spec: the importable-resource registry, the reconcilable leaf-field list, and the required-keys set. The module is reusable by any Crossplane v2 composition.

## Testing

- CompositionTest suite `tests/test-eks-import` (observe / missing-blocks-render / commit).
- Also fixes a pre-existing failure in `tests/test-eks-sequence` (stale `metadata.name` overrides on observed resources; composition untouched).
- All four suites pass: `test-eks-import` 3/3, `test-eks-sequence` 5/5, `test-eks-iam` 1/1, `test-eks-cluster-security-group` 1/1.
- Validated end-to-end on a development control plane against a live `eksctl`-created cluster: observe (zero mutation) → drift/side-effect report → reconcile path.

## Files

- `apis/eks/definition.yaml` — `import` + `network` parameters, `status.import`.
- `functions/eks/main.k` — import wiring (external names, management policies, EKS import spec).
- `functions/eks/importkit.k` — new generic import engine.
- `tests/test-eks-import/` — new suite; `tests/test-eks-sequence/main.k` — fixture fix.
- `examples/eks/eks-import-xr.yaml`, `README.md` — docs.
